### PR TITLE
Prepend base url to request path

### DIFF
--- a/lib/wallaby/dsl/navigation.ex
+++ b/lib/wallaby/dsl/navigation.ex
@@ -3,8 +3,8 @@ defmodule Wallaby.DSL.Navigation do
   alias Wallaby.XPath
   alias Wallaby.DSL.Actions
 
-  def visit(session, url) do
-    Session.request(:post, "#{session.base_url}session/#{session.id}/url", %{url: url})
+  def visit(session, path) do
+    Session.request(:post, "#{session.base_url}session/#{session.id}/url", %{url: request_url(path)})
     session
   end
 
@@ -13,4 +13,6 @@ defmodule Wallaby.DSL.Navigation do
     |> Actions.click
     session
   end
+
+  defp request_url(url), do: (Application.get_env(:wallaby, :base_url) || "") <> url
 end

--- a/test/wallaby/dsl_test.exs
+++ b/test/wallaby/dsl_test.exs
@@ -139,8 +139,21 @@ defmodule Wallaby.DSLTest do
 
     find(session, "#option2")
     |> choose()
-    
+
     refute find(session, "#option1") |> checked?
     assert find(session, "#option2") |> checked?
+  end
+
+  test "navigating by path only", %{session: session, server: server} do
+    Application.put_env(:wallaby, :base_url, server.base_url)
+    session
+    |> visit("page_1.html")
+
+    element =
+      session
+      |> find(".blue")
+
+    assert element
+    Application.put_env(:wallaby, :base_url, nil)
   end
 end


### PR DESCRIPTION
It'd be nice not to have to write out the full url on each `visit`. In test_helper.exs:

```
{:ok, _} = Application.ensure_all_started(:wallaby)
Application.put_env(:wallaby, :base_url, Allocations.Endpoint.url)
```

then `visit("/sign_in")` would navigate to http://localhost:4001/sign_in.