### PR TITLE
Make wait time configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :wallaby, max_wait_time: 3_000
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/wallaby/dsl/finders.ex
+++ b/lib/wallaby/dsl/finders.ex
@@ -3,8 +3,6 @@ defmodule Wallaby.DSL.Finders do
   alias Wallaby.Node
   alias Wallaby.Driver
 
-  @default_max_wait_time 3_000
-
   def find(locator, query, opts \\ []) do
     retry fn ->
       locator
@@ -28,7 +26,7 @@ defmodule Wallaby.DSL.Finders do
     end
   end
 
-  defp retry(find_fn, max_wait_time \\ @default_max_wait_time, start_time \\ :erlang.monotonic_time(:milli_seconds)) do
+  defp retry(find_fn, start_time \\ :erlang.monotonic_time(:milli_seconds)) do
     try do
       find_fn.()
     rescue
@@ -36,10 +34,14 @@ defmodule Wallaby.DSL.Finders do
         current_time = :erlang.monotonic_time(:milli_seconds)
         if current_time - start_time < max_wait_time do
           :timer.sleep(25)
-          retry(find_fn, max_wait_time, start_time)
+          retry(find_fn, start_time)
         else
           raise e
         end
     end
+  end
+
+  defp max_wait_time do
+    Application.get_env(:wallaby, :max_wait_time)
   end
 end

--- a/lib/wallaby/dsl/helpers.ex
+++ b/lib/wallaby/dsl/helpers.ex
@@ -1,7 +1,11 @@
 defmodule Wallaby.DSL.Helpers do
-  alias Wallaby.Session
+  alias Wallaby.Node
   alias Wallaby.Driver
 
+  def take_screenshot(%Node{session: session}=node) do
+    take_screenshot(session)
+    node
+  end
   def take_screenshot(session) do
     Driver.take_screenshot(session)
   end


### PR DESCRIPTION
Allow maximum wait times to be configurable. This allows for extended wait times on slow boxes (like on ci servers)