### PR TITLE
Clear the text from the node before its filled in

### DIFF
--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -79,8 +79,8 @@ defmodule Wallaby.Node do
   end
 
   def fill_in(%Node{session: session}=node, with: value) when is_binary(value) do
-    node
-    |> Driver.set_value(value)
+    clear(node)
+    Driver.set_value(node, value)
     session
   end
 

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -122,6 +122,15 @@ defmodule Wallaby.NodeTest do
     assert find(session, "#email_field") |> has_value?("alex@example.com")
   end
 
+  test "fill_in replaces all of the text", %{server: server, session: session} do
+    session
+    |> visit(server.base_url <> "forms.html")
+    |> fill_in("name", with: "Chris")
+    |> fill_in("name", with: "Alex")
+
+    assert find(session, "#name_field") |> has_value?("Alex")
+  end
+
   test "clearing input", %{server: server, session: session} do
     node =
       session


### PR DESCRIPTION
Clears out the node before we call fill_in. Semantically fill_in should not append to the text in the input.

Closes #18 