### PR TITLE
Matches has_css? and has_no_css?

### DIFF
--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -5,3 +5,7 @@ end
 defmodule Wallaby.ElementNotFound do
   defexception [:message]
 end
+
+defmodule Wallaby.ExpectationNotMet do
+  defexception [:message]
+end

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -216,6 +216,25 @@ defmodule Wallaby.Node do
   end
 
   @doc """
+  Searches for CSS on the page.
+  """
+  @spec has_css?(locator, String.t) :: boolean()
+
+  def has_css?(locator, css) when is_binary(css) do
+    find(locator, css, [count: :any])
+    |> Enum.any?
+  end
+
+  @doc """
+  Searches for css that should not be on the page
+  """
+  @spec has_no_css?(locator, String.t) :: boolean()
+
+  def has_no_css?(locator, css) when is_binary(css) do
+    find(locator, css, count: 0)
+  end
+
+  @doc """
   Checks if the node has been selected.
   """
   @spec checked?(t) :: boolean()
@@ -229,6 +248,7 @@ defmodule Wallaby.Node do
       elements when length(elements) > 0 and count == :any -> elements
       [element] when length(elements) == count -> element
       elements when length(elements) == count -> elements
+      elements when length(elements) > 0 and count == 0 -> raise Wallaby.ExpectationNotMet, message: "Element was found"
       [] -> raise Wallaby.ElementNotFound, message: "Could not find element"
       elements -> raise Wallaby.AmbiguousMatch, message: "Ambiguous match, found #{length(elements)}"
     end
@@ -238,7 +258,7 @@ defmodule Wallaby.Node do
     try do
       find_fn.()
     rescue
-      e in [Wallaby.ElementNotFound, Wallaby.AmbiguousMatch] ->
+      e in [Wallaby.ElementNotFound, Wallaby.AmbiguousMatch, Wallaby.ExpectationNotMet] ->
         current_time = :erlang.monotonic_time(:milli_seconds)
         if current_time - start_time < max_wait_time do
           :timer.sleep(25)

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -259,4 +259,28 @@ defmodule Wallaby.NodeTest do
 
     assert find(session, "li", count: :any) |> length == 4
   end
+
+  test "has_css/2 returns true if the css is on the page", %{session: session, server: server} do
+    page =
+      session
+      |> visit(server.base_url <> "nesting.html")
+
+    assert has_css?(page, ".user")
+  end
+
+  test "has_no_css/2 checks is the css is not on the page", %{session: session, server: server} do
+    page =
+      session
+      |> visit(server.base_url <> "nesting.html")
+
+    assert has_no_css?(page, ".something_else")
+  end
+
+  test "has_no_css/2 raises error if the css is found", %{session: session, server: server} do
+    assert_raise Wallaby.ExpectationNotMet, fn ->
+      session
+      |> visit(server.base_url <> "nesting.html")
+      |> has_no_css?(".user")
+    end
+  end
 end


### PR DESCRIPTION
We can use these matchers to assert that dom elements are visible or no longer visible. They also block the page until they either become true or until the max wait time is reached which means they can be used to help with async tests.

Closes #13 