### PR TITLE
Only find visible elements by default

### DIFF
--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -167,6 +167,37 @@ defmodule Wallaby.Driver do
   end
 
   @doc """
+  Checks if the node is being displayed.
+
+  This is based on what is available in phantom and doesn't match the current
+  specification.
+  """
+  def displayed(node) do
+    response = request(:get, "#{node.session.base_url}session/#{node.session.id}/element/#{node.id}/displayed")
+    response["value"]
+  end
+
+  @doc """
+  Gets the size of a node.
+
+  This is non-standard and only works in Phantom.
+  """
+  def size(node) do
+    response = request(:get, "#{node.session.base_url}session/#{node.session.id}/element/#{node.id}/size")
+    response["value"]
+  end
+
+  @doc """
+  Gets the height, width, x, and y position of an Element.
+
+  This is based on the standard but currently is un-supported by Phantom.
+  """
+  def rect(node) do
+    response = request(:get, "#{node.session.base_url}session/#{node.session.id}/element/#{node.id}/rect")
+    response["value"]
+  end
+
+  @doc """
   Takes a screenshot.
   """
   def take_screenshot(session) do

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -41,7 +41,8 @@ defmodule Wallaby.Node do
   Finds a specific DOM node on the page based on a css selector. Blocks until
   it either finds the node or until the max time is reached. By default only
   1 node is expected to match the query. If more nodes are present then a
-  count can be specified.
+  count can be specified. By default only nodes that are visible on the page
+  are returned.
 
   Selections can be scoped by providing a Node as the locator for the query.
   """
@@ -51,6 +52,7 @@ defmodule Wallaby.Node do
     retry fn ->
       locator
       |> Driver.find_elements(query)
+      |> assert_visibility(Keyword.get(opts, :visible, true))
       |> assert_element_count(Keyword.get(opts, :count, 1))
     end
   end
@@ -277,6 +279,15 @@ defmodule Wallaby.Node do
     checked?(node)
   end
 
+  @doc """
+  Checks if the node is visible on the page
+  """
+  @spec visible?(t) :: boolean()
+
+  def visible?(%Node{}=node) do
+    Driver.displayed(node)
+  end
+
   defp assert_element_count(elements, count) when is_list(elements) do
     case elements do
       elements when length(elements) > 0 and count == :any -> elements
@@ -285,6 +296,14 @@ defmodule Wallaby.Node do
       elements when length(elements) > 0 and count == 0 -> raise Wallaby.ExpectationNotMet, message: "Element was found"
       [] -> raise Wallaby.ElementNotFound, message: "Could not find element"
       elements -> raise Wallaby.AmbiguousMatch, message: "Ambiguous match, found #{length(elements)}"
+    end
+  end
+
+  defp assert_visibility(elements, visible) when is_list(elements) do
+    if Enum.all?(elements, &(visible?(&1) == visible)) do
+      elements
+    else
+      raise Wallaby.ElementNotFound, message: "Could not find element"
     end
   end
 

--- a/lib/wallaby/xpath.ex
+++ b/lib/wallaby/xpath.ex
@@ -5,9 +5,6 @@ defmodule Wallaby.XPath do
   @type id    :: query
   @type label :: query
 
-  import Wallaby.XPath.Builder
-  import Wallaby.XPath.Render
-
   @doc """
   XPath for links
   this xpath is gracious ripped from capybara via
@@ -17,6 +14,9 @@ defmodule Wallaby.XPath do
     ".//a[./@href][(((./@id = '#{lnk}' or contains(normalize-space(string(.)), '#{lnk}')) or contains(./@title, '#{lnk}')) or .//img[contains(./@alt, '#{lnk}')])]"
   end
 
+  @doc """
+  Match any radio buttons
+  """
   def radio_button(query) do
     ".//input[./@type = 'radio'][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//input[./@type = 'radio']"
   end
@@ -30,6 +30,9 @@ defmodule Wallaby.XPath do
     ".//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]"
   end
 
+  @doc """
+  Match any checkboxes
+  """
   def checkbox(query) do
     ".//input[./@type = 'checkbox'][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//input[./@type = 'checkbox']"
   end
@@ -46,17 +49,5 @@ defmodule Wallaby.XPath do
   """
   def option_for(query) do
     ".//option[normalize-space(text())='#{query}']"
-  end
-
-  defp fillable_fields do
-    ["textarea", "input"]
-  end
-
-  defp unfillable_fields do
-    attr("type", ["checkbox", "submit", "button"])
-  end
-
-  defp field_locator(query) do
-    any([attr("id", query), attr("name", query), attr("placeholder", query), ])
   end
 end

--- a/test/support/pages/wait.html
+++ b/test/support/pages/wait.html
@@ -7,7 +7,10 @@
     <script type="text/javascript">
       function addElement(className) {
         var node = document.createElement("div")
+          , text = document.createTextNode(className)
         node.className = className
+        node.appendChild(text)
+        
         document.body.appendChild(node)
       }
 

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -379,4 +379,31 @@ defmodule Wallaby.NodeTest do
 
     assert find(session, ".blue")
   end
+
+  test "find/2 raises an error if the element is not visible", %{session: session, server: server} do
+    session
+    |> visit(server.base_url <> "page_1.html")
+
+    assert_raise Wallaby.ElementNotFound, fn ->
+      find(session, "#invisible", count: :any)
+    end
+
+    assert find(session, "#visible", count: :any) |> length == 1
+  end
+
+  test "visible?/1 determines if the node is visible on the page", %{session: session, server: server} do
+    page =
+      session
+      |> visit(server.base_url <> "page_1.html")
+
+    page
+    |> find("#visible")
+    |> visible?
+    |> assert
+
+    page
+    |> find("#invisible", visible: false)
+    |> visible?
+    |> refute
+  end
 end


### PR DESCRIPTION
Finders should only return visible elements by default.

If this needs to be overwritten for some reason then a `visible: false` option can be passed to the finder like so: `find(session, ".some_element", visible: false)`.

The correct solution for determining visibility is to either use the webdriver standard `get_element_rect` or to query for the element and then get the bounding rectangle for the element. If its 0 then the element isn't visible. However, Phantom doesn't implement the `rect` endpoint. Instead it implements the `size` endpoint and (conveniently) a `displayed` endpoint. I've left all 3 solutions in for now. I'd like to consolidate and clean this up by moving some of this logic to a phantom specific driver so that its at least isolated. But that can be future work once we actually start supporting something like selenium.

This works for now.

Closes #26 