### PR TITLE
Fix intermitent errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :wallaby, max_wait_time: 3_000
+config :wallaby, max_wait_time: 7_000
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :wallaby, max_wait_time: 7_000
+config :wallaby, max_wait_time: 1_000
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -1,4 +1,8 @@
 defmodule Wallaby.Driver do
+  @moduledoc """
+  Implements the webdriver protocol for Phantomjs
+  """
+
   alias Wallaby.Session
   alias Wallaby.Node
 
@@ -7,63 +11,6 @@ defmodule Wallaby.Driver do
   @type query :: String.t
   @type params :: %{using: String.t, value: query}
   @type locator :: Session.t | Node.t
-
-  @moduledoc """
-  List of all endpoints to implement for webdriver protocol
-
-  | Method | URI Template	                                         | Command   |
-  | -------|-------------------------------------------------------|-----------|
-  | POST	 | /session	New Session
-  | DELETE | /session/{session id}	Delete Session
-  | POST	 | /session/{session id}/url	Get
-  | GET	   | /session/{session id}/url	Get Current URL
-  | POST	 | /session/{session id}/back	Back
-  | POST	 | /session/{session id}/forward	Forward
-  | POST	 | /session/{session id}/refresh	Refresh
-  | GET	   | /session/{session id}/title	Get Title
-  | GET	   | /session/{session id}/window	Get Window Handle
-  | DELETE | /session/{session id}/window	Close Window
-  | POST	 | /session/{session id}/window	Switch To Window
-  | GET	   | /session/{session id}/window/handles	Get Window Handles
-  | POST	 | /session/{session id}/window/fullscreen	Fullscreen Window
-  | POST	 | /session/{session id}/window/maximize	Maximize Window
-  | POST	 | /session/{session id}/window/size	Set Window Size
-  | GET	   | /session/{session id}/window/size	Get Window Size
-  | POST	 | /session/{session id}/frame	Switch To Frame
-  | POST	 | /session/{session id}/frame/parent	Switch To Parent Frame
-  | POST	 | /session/{session id}/element	Find Element
-  | POST	 | /session/{session id}/element/{element id}/element	Find Element From Element
-  | POST	 | /session/{session id}/elements	Find Elements
-  | POST	 | /session/{session id}/element/{element id}/elements	Find Elements From Element
-  | GET	   | /session/{session id}/element/active	Get Active Element
-  | GET	   | /session/{session id}/element/{element id}/selected	Is Element Selected
-  | GET	   | /session/{session id}/element/{element id}/attribute/{name}	Get Element Attribute
-  | GET	   | /session/{session id}/element/{element id}/property/{name}	Get Element Property
-  | GET	   | /session/{session id}/element/{element id}/css/{property name}	Get Element CSS Value
-  | GET	   | /session/{session id}/element/{element id}/text	Get Element Text
-  | GET	   | /session/{session id}/element/{element id}/name	Get Element Tag Name
-  | GET	   | /session/{session id}/element/{element id}/rect	Get Element Rect
-  | GET	   | /session/{session id}/element/{element id}/enabled	Is Element Enabled
-  | GET	   | /session/{session id}/source	Get Page Source
-  | POST	 | /session/{session id}/execute/sync	Execute Script
-  | POST	 | /session/{session id}/execute/async	Execute Async Script
-  | GET	   | /session/{session id}/cookie/{name}	Get Cookie
-  | POST	 | /session/{session id}/cookie	Add Cookie
-  | DELETE | /session/{session id}/cookie/{name}	Delete Cookie
-  | DELETE | /session/{session id)/cookie	Delete All Cookies
-  | POST	 | /session/{session id}/timeouts	Set Timeout
-  | POST	 | /session/{session id}/actions	Perform Actions
-  | DELETE | /session/{session id}/actions	Releasing Actions
-  | POST	 | /session/{session id}/element/{element id}/click	Element Click
-  | POST	 | /session/{session id}/element/{element id}/clear	Element Clear
-  | POST	 | /session/{session id}/element/{element id}/sendKeys	Element Send Keys
-  | POST	 | /session/{session id}/alert/dismiss	Dismiss Alert
-  | POST	 | /session/{session id}/alert/accept	Accept Alert
-  | GET	   | /session/{session id}/alert/text	Get Alert Text
-  | POST	 | /session/{session id}/alert/text	Send Alert Text
-  | GET	   | /session/{session id}/screenshot	Take Screenshot
-  | GET	   | /session/{session id}/element/{element id}/screenshot	Take Element Screenshot
-  """
 
   def create(server) do
     base_url = Wallaby.Server.get_base_url(server)
@@ -153,6 +100,14 @@ defmodule Wallaby.Driver do
   def visit(session, path) do
     request(:post, "#{session.base_url}session/#{session.id}/url", %{url: path})
     session
+  end
+
+  @doc """
+  Gets the current url.
+  """
+  def current_url(session) do
+    resp = request(:get, "#{session.base_url}session/#{session.id}/url")
+    resp["value"]
   end
 
   @doc """

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -314,7 +314,7 @@ defmodule Wallaby.Node do
     rescue
       e in [Wallaby.ElementNotFound, Wallaby.AmbiguousMatch, Wallaby.ExpectationNotMet] ->
         current_time = :erlang.monotonic_time(:milli_seconds)
-        if current_time - start_time < max_wait_time do
+        if (current_time - start_time) < max_wait_time do
           :timer.sleep(25)
           retry(find_fn, start_time)
         else

--- a/test/wallaby/session_test.exs
+++ b/test/wallaby/session_test.exs
@@ -1,5 +1,5 @@
 defmodule Wallaby.SessionTest do
-  use Wallaby.ServerCase, async: true
+  use Wallaby.ServerCase, async: false
   use Wallaby.DSL
 
   setup do


### PR DESCRIPTION
This fixes some of the intermittent failures that we've been seeing in the internal test suite.

The issue was that the Session test was set to `async: true`. However, one of the tests in that test case mutates global Application state (by setting an config value as part of a test). The test was changing the `:base_url` config value for the application. Because it was running async other tests had the possibility of running while that config value was set. The issue was that test would then try to navigate to a route like `http://localhost:1234/http://localhost:1235/page_1.html` or something similar. Since that route doesn't exist it can't ever find anything. I'm not sure if there's a better way to handle errors like that. The page never loads since it doesn't exist. But I'm not sure if we can get those errors out of phantom. Errors like that would definitely have helped track down this error.