### PR TITLE
Features/has text retry

### DIFF
--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -242,11 +242,11 @@ defmodule Wallaby.Node do
 
   def has_text?(%Node{}=node, text) when is_binary(text) do
     retry fn ->
-      not_found = Regex.run(~r/#{text}/, text(node)) |> is_nil
-      if not_found do
+      regex_results = Regex.run(~r/#{text}/, text(node))
+      if regex_results |> is_nil do
         raise Wallaby.ExpectationNotMet, "Text '#{text}' not found"
       end
-      !not_found
+      true
     end
   end
 

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -236,17 +236,30 @@ defmodule Wallaby.Node do
   end
 
   @doc """
-  Matches the Node's content with the provided text.
+  Matches the Node's content with the provided text and raises if not found
   """
-  @spec has_text?(t, String.t) :: boolean()
+  @spec assert_text(t, String.t) :: boolean()
 
-  def has_text?(%Node{}=node, text) when is_binary(text) do
+  def assert_text(%Node{}=node, text) when is_binary(text) do
     retry fn ->
       regex_results = Regex.run(~r/#{text}/, text(node))
       if regex_results |> is_nil do
         raise Wallaby.ExpectationNotMet, "Text '#{text}' not found"
       end
       true
+    end
+  end
+
+  @doc """
+  Matches the Node's content with the provided text
+  """
+  @spec has_text?(t, String.t) :: boolean()
+
+  def has_text?(%Node{}=node, text) when is_binary(text) do
+    try do
+      assert_text(node, text)
+    rescue
+      e in Wallaby.ExpectationNotMet -> false
     end
   end
 

--- a/test/support/pages/index.html
+++ b/test/support/pages/index.html
@@ -10,5 +10,12 @@
       <li><a href="page_2.html">Page 2</a></li>
       <li><a href="page_3.html">Page 3</a></li>
     </ul>
+
+    <div id="parent">
+      The Parent
+      <div id="child">
+        The Child
+      </div>
+    </div>
   </body>
 </html>

--- a/test/support/pages/wait.html
+++ b/test/support/pages/wait.html
@@ -11,7 +11,7 @@
         node.className = className
         node.appendChild(text)
         
-        document.body.appendChild(node)
+        document.getElementById("container").appendChild(node)
       }
 
       setTimeout(function() {
@@ -20,5 +20,7 @@
         for (i = 0; i < 5; i++) { addElement("orange") }
       }, 1000)
     </script>
+    <div id="container">
+    </div>
   </body>
 </html>

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -105,6 +105,17 @@ defmodule Wallaby.NodeTest do
     assert has_text?(node, "main")
   end
 
+  test "has_text?/2 will raise an exception for text not found", %{server: server, session: session} do
+    node =
+    session
+      |> visit(server.base_url <> "wait.html")
+      |> find("#container")
+
+    assert_raise Wallaby.ExpectationNotMet, "Text 'rain' not found", fn ->
+      has_text?(node, "rain")
+    end
+  end
+
   test "can get attributes of an element", %{server: server, session: session} do
     class =
       session

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -87,32 +87,33 @@ defmodule Wallaby.NodeTest do
     assert text == "The Parent\nThe Child"
   end
 
-  test "has_text?/2 asserts text in an element", %{server: server, session: session} do
-    node =
-      session
-      |> visit(server.base_url)
-      |> find("#header")
-
-    assert has_text?(node, "Test Index")
-  end
-
-  test "has_text?/2 will retry for presence of text", %{server: server, session: session} do
+  test "has_text?/2 waits for presence of text and returns a bool", %{server: server, session: session} do
     node =
     session
       |> visit(server.base_url <> "wait.html")
       |> find("#container")
 
     assert has_text?(node, "main")
+    refute has_text?(node, "rain")
   end
 
-  test "has_text?/2 will raise an exception for text not found", %{server: server, session: session} do
+  test "assert_text/2 waits for presence of text and and returns true if found", %{server: server, session: session} do
+    node =
+    session
+      |> visit(server.base_url <> "wait.html")
+      |> find("#container")
+
+    assert assert_text(node, "main")
+  end
+
+  test "assert_text/2 will raise an exception for text not found", %{server: server, session: session} do
     node =
     session
       |> visit(server.base_url <> "wait.html")
       |> find("#container")
 
     assert_raise Wallaby.ExpectationNotMet, "Text 'rain' not found", fn ->
-      has_text?(node, "rain")
+      assert_text(node, "rain")
     end
   end
 

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -77,13 +77,32 @@ defmodule Wallaby.NodeTest do
     assert text == "Test Index"
   end
 
-  test "has_content?/2 asserts text in an element", %{server: server, session: session} do
+  test "can get text of an element and its descendants", %{server: server, session: session} do
+    text =
+      session
+      |> visit(server.base_url)
+      |> find("#parent")
+      |> text
+
+    assert text == "The Parent\nThe Child"
+  end
+
+  test "has_text?/2 asserts text in an element", %{server: server, session: session} do
     node =
       session
       |> visit(server.base_url)
       |> find("#header")
 
-    assert has_content?(node, "Test Index")
+    assert has_text?(node, "Test Index")
+  end
+
+  test "has_text?/2 will retry for presence of text", %{server: server, session: session} do
+    node =
+    session
+      |> visit(server.base_url <> "wait.html")
+      |> find("#container")
+
+    assert has_text?(node, "main")
   end
 
   test "can get attributes of an element", %{server: server, session: session} do


### PR DESCRIPTION
Here's a shot at introducing a ``has_text?`` method, which replaces ``has_content?``

The intent of this method is to have it behave like ``find/2``, which retries. This would allow us to use text as keyframes for state of a page, e.g.

```elixir
assert node |> has_text?('Record updated!')
```

Some implications:

- ``has_text?/2`` allows for partial matching; this would allow us for to search for text on a page, rather than having to know the node ahead of time
- ``has_text?/2`` raises a Wallaby.ExpectationNotMet error instead of returning false
- ``text/2`` is not altered. It just returns the text of the node at that time