### PR TITLE
Use new ecto sandbox metadata api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then ensure that Wallaby is started in your `test_helper.exs`:
 
 If you're testing a Phoenix application with Ecto then you can enable concurrent testing by adding the `Phoenix.Ecto.SQL.Sandbox` to your `Endpoint`
 
-**Note:** This requires Ecto v2.0.0-beta1 or newer.
+**Note:** This requires Ecto v2.0.0-rc.0 or newer.
 
 ```elixir
 # lib/endpoint.ex
@@ -79,8 +79,8 @@ defmodule YourApp.AcceptanceCase do
 
   setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
-    {:ok, session} = Wallaby.start_session
-    Wallaby.Session.visit(session, Phoenix.Ecto.SQL.Sandbox.path_for(YourApp.Repo, self()))
+    metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
+    {:ok, session} = Wallaby.start_session(metadata: metadata)
     {:ok, session: session}
   end
 end

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -13,7 +13,7 @@ defmodule Wallaby do
 
   def start_session(opts \\ []) do
     server = :poolboy.checkout(Wallaby.ServerPool)
-    Wallaby.Driver.create(server)
+    Wallaby.Driver.create(server, opts)
   end
 
   def end_session(%Wallaby.Session{server: server}) do

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -11,7 +11,7 @@ defmodule Wallaby do
     :poolboy.start_link(pool_opts, [])
   end
 
-  def start_session do
+  def start_session(opts \\ []) do
     server = :poolboy.checkout(Wallaby.ServerPool)
     Wallaby.Driver.create(server)
   end

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -12,22 +12,18 @@ defmodule Wallaby.Driver do
   @type params :: %{using: String.t, value: query}
   @type locator :: Session.t | Node.t
 
-  def create(server) do
+  @doc """
+  Creates a new session with the driver.
+  """
+  def create(server, opts) do
     base_url = Wallaby.Server.get_base_url(server)
+    user_agent =
+      Wallaby.Phantom.user_agent
+      |> Wallaby.Metadata.append(opts[:metadata])
 
-    params = %{
-      desiredCapabilities: %{
-        javascriptEnabled: false,
-        version: "",
-        rotatable: false,
-        takesScreenshot: true,
-        cssSelectorsEnabled: true,
-        browserName: "phantomjs",
-        nativeEvents: false,
-        platform: "ANY"
-      }
-    }
-
+    capabilities = Wallaby.Phantom.capabilities(user_agent: user_agent)
+    params = %{desiredCapabilities: capabilities}
+    
     response = request(:post, "#{base_url}session", params)
     session = %Wallaby.Session{base_url: base_url, id: response["sessionId"], server: server}
     {:ok, session}

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -9,3 +9,7 @@ end
 defmodule Wallaby.ExpectationNotMet do
   defexception [:message]
 end
+
+defmodule Wallaby.BadMetadata do
+  defexception [:message]
+end

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -45,7 +45,7 @@ defmodule Wallaby.Metadata do
     |> :erlang.binary_to_term
     |> case do
         {:v1, metadata} -> metadata
-        _               -> IO.puts "Whelp"
+        _               -> raise Wallaby.BadMetadata, message: "#{encoded_metadata} is not valid"
       end
   end
 end

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -6,8 +6,9 @@ defmodule Wallaby.Metadata do
   """
 
   @prefix "BeamMetadata"
-  @regex ~r{#{@metadata_prefix} \((.*?)\)}
+  @regex ~r{#{@prefix} \((.*?)\)}
 
+  def append(user_agent, nil), do: user_agent
   def append(user_agent, metadata) when is_map(metadata) or is_list(metadata) do
     append(user_agent, format(metadata))
   end
@@ -23,7 +24,7 @@ defmodule Wallaby.Metadata do
       {:v1, metadata}
       |> :erlang.term_to_binary
       |> Base.url_encode64
-    "#{@prefix} (#{{encoded}})"
+    "#{@prefix} (#{encoded})"
   end
 
   def extract(str) do

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -1,0 +1,50 @@
+defmodule Wallaby.Metadata do
+  @moduledoc """
+  Metadata is used to encode information about the browser and test. This
+  information is then stored in a User Agent string. The information from the
+  test can then be extracted in the application.
+  """
+
+  @prefix "BeamMetadata"
+  @regex ~r{#{@metadata_prefix} \((.*?)\)}
+
+  def append(user_agent, metadata) when is_map(metadata) or is_list(metadata) do
+    append(user_agent, format(metadata))
+  end
+  def append(user_agent, metadata) when is_binary(metadata) do
+    "#{user_agent}/#{metadata}"
+  end
+
+  @doc """
+  Formats a string to a valid UserAgent string.
+  """
+  def format(metadata) do
+    encoded =
+      {:v1, metadata}
+      |> :erlang.term_to_binary
+      |> Base.url_encode64
+    "#{@prefix} (#{{encoded}})"
+  end
+
+  def extract(str) do
+    ua =
+      str
+      |> String.split("/")
+      |> List.last
+
+    case Regex.run(@regex, ua) do
+      [_, metadata] -> parse(metadata)
+      _             -> %{}
+    end
+  end
+
+  def parse(encoded_metadata) do
+    encoded_metadata
+    |> Base.url_decode64!
+    |> :erlang.binary_to_term
+    |> case do
+        {:v1, metadata} -> metadata
+        _               -> IO.puts "Whelp"
+      end
+  end
+end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -1,0 +1,28 @@
+defmodule Wallaby.Phantom do
+  def capabilities(opts) do
+    default_capabilities
+    |> Map.merge(user_agent_capability(opts[:user_agent]))
+  end
+
+  def default_capabilities do
+    %{
+      javascriptEnabled: false,
+      version: "",
+      rotatable: false,
+      takesScreenshot: true,
+      cssSelectorsEnabled: true,
+      browserName: "phantomjs",
+      nativeEvents: false,
+      platform: "ANY"
+    }
+  end
+
+  def user_agent do
+    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
+  end
+
+  def user_agent_capability(nil), do: %{}
+  def user_agent_capability(ua) do
+    %{"phantomjs.page.settings.userAgent" => ua}
+  end
+end

--- a/test/wallaby/metadata_test.exs
+++ b/test/wallaby/metadata_test.exs
@@ -1,0 +1,2 @@
+defmodule Wallaby.MetadataTest do
+end


### PR DESCRIPTION
The phoenix_ecto sandbox plug now accepts metadata inside the user agent string (see phoenixframework/phoenix_ecto#44). We can use that to pass db ownership information back to Phoenix and Ecto.