### PR TITLE
Raise exception is there is no base_url set

### DIFF
--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -13,3 +13,21 @@ end
 defmodule Wallaby.BadMetadata do
   defexception [:message]
 end
+
+defmodule Wallaby.NoBaseUrl do
+  defexception [:message]
+
+  def exception(relative_path) do
+    msg = """
+    You called visit with #{relative_path}, but did not set a base_url.
+    Set this in config/test.exs or in test/test_helper.exs:
+
+      Application.put_env(:wallaby, :base_url, "http://localhost:4001")
+
+    If using Phoenix, you can use the url from your endpoint:
+
+      Application.put_env(:wallaby, :base_url, YourApplication.Endpoint.url)
+    """
+    %__MODULE__{message: msg}
+  end
+end

--- a/test/wallaby/session_test.exs
+++ b/test/wallaby/session_test.exs
@@ -37,6 +37,21 @@ defmodule Wallaby.SessionTest do
     Application.put_env(:wallaby, :base_url, nil)
   end
 
+  test "visit/2 with a relative url and no base url raises exception", %{session: session, server: server} do
+    assert_raise(Wallaby.NoBaseUrl, fn ->
+      Application.put_env(:wallaby, :base_url, nil)
+      session
+      |> visit("/page_1.html")
+    end)
+  end
+
+  test "visit/2 with an absolute path does not use the base url", %{session: session, server: server} do
+    session
+    |> visit(server.base_url <> "/page_1.html")
+
+    assert has_css?(session, "#visible")
+  end
+
   test "taking screenshots", %{session: session, server: server} do
     node =
       session


### PR DESCRIPTION
Supplying a relative url when there is no base_url set can result in some opaque errors. Instead we can just return a well defined error to the user with instructions on how to set up a base_url.

Closes #36.