### PR TITLE
Add shared config to AcceptanceCase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ defmodule YourApp.AcceptanceCase do
     end
   end
 
-  setup _tags do
+  setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(YourApp.Repo, {:shared, self()})
+    end
     metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
     {:ok, session} = Wallaby.start_session(metadata: metadata)
     {:ok, session: session}


### PR DESCRIPTION
Manually checking out connections currently doesn't work for things like making a query from a `FooChannel.join` callback or a background job so you can't run your tests async in these cases. Having the `unless tags[:async]` bit in the AcceptanceCase matches what Phoenix does and allows you to quickly toggle between async and sync when you run into this.