### PR TITLE
Return the session from the choose action

### DIFF
--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -136,8 +136,11 @@ defmodule Wallaby.Node do
   @spec choose(Node.t) :: Session.t
 
   def choose(%Session{}=session, query) when is_binary(query) do
-    find(session, {:xpath, radio_button(query)})
+    session
+    |> find({:xpath, radio_button(query)})
     |> click
+
+    session
   end
 
   def choose(%Node{}=node) do

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -256,6 +256,15 @@ defmodule Wallaby.NodeTest do
     assert find(session, "#option2") |> checked?
   end
 
+  test "choosing a radio button returns the parent", %{session: session, server: server} do
+    session
+    |> visit(server.base_url <> "forms.html")
+    |> choose("Option 1")
+    |> choose("option2")
+
+    assert find(session, "#option2") |> checked?
+  end
+
   test "check/1 checks the specified node", %{session: session, server: server} do
     checkbox =
       session


### PR DESCRIPTION
The choose action should return the session instead of the node so that it can be chained properly.