### PR TITLE
Update version in README to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add wallaby to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:wallaby, "~> 0.5.0"}]
+  [{:wallaby, "~> 0.7.0"}]
 end
 ```
 


### PR DESCRIPTION
BTW I don't know whether there is a community solution for that, but every library seems to specify the version number in the README and it's quite easy to forget to update it in the README while doing a release.