### PR TITLE
Extra screenshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,28 @@ take_screenshot(session)
 
 All screenshots are saved to a `screenshots` directory in the directory that the tests were run in.
 
+If you want to customize the screenshot directory you can pass it as a config value:
+
+```elixir
+# config/test.exs
+config :wallaby, screenshot_dir: "/file/path"
+
+# test_helper.exs
+Application.put_env(:wallaby, :screenshot_dir, "/file/path")
+```
+
+### Automatic screenshots
+
+You can automatically take screenshots on an error:
+
+```elixir
+# config/test.exs
+config :wallaby, screenshot_on_failure: true
+
+# test_helper.exs
+Application.put_env(:wallaby, :screenshot_on_failure, true)
+```
+
 ## Javascript applications and asynchronous code.
 
 It can be difficult to test asynchronous javascript code. You may try to interact with an element that isn't visible on the page. Wallaby's finders try to help mitigate this problem by blocking until the element becomes visible. You can use this strategy by writing tests in this way:

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -19,4 +19,8 @@ defmodule Wallaby do
   def end_session(%Wallaby.Session{server: server}) do
     :poolboy.checkin(Wallaby.ServerPool, server)
   end
+
+  def screenshot_on_failure? do
+    Application.get_env(:wallaby, :screenshot_on_failure)
+  end
 end

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -160,14 +160,9 @@ defmodule Wallaby.Driver do
   Takes a screenshot.
   """
   def take_screenshot(session) do
-    image_data =
-      request(:get, "#{session.base_url}session/#{session.id}/screenshot")
-      |> Map.get("value")
-      |> :base64.decode
-
-    path = path_for_screenshot
-    File.write! path, image_data
-    path
+    request(:get, "#{session.base_url}session/#{session.id}/screenshot")
+    |> Map.get("value")
+    |> :base64.decode
   end
 
   @doc """
@@ -222,15 +217,6 @@ defmodule Wallaby.Driver do
       :post,
       "#{session.base_url}session/#{session.id}/keys",
       %{value: [text]})
-  end
-
-  defp path_for_screenshot do
-    {hour, minutes, seconds} = :erlang.time()
-    {year, month, day} = :erlang.date()
-
-    screenshot_dir = "#{File.cwd!()}/screenshots"
-    File.mkdir_p!(screenshot_dir)
-    "#{screenshot_dir}/#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.png"
   end
 
   defp window_handle(session) do

--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -79,7 +79,7 @@ defmodule Wallaby.Node.Query do
       {:ok, elements} ->
         elements
       {:error, e} ->
-        handle_error(e)
+        cleanup(e)
     end
   end
 
@@ -103,7 +103,7 @@ defmodule Wallaby.Node.Query do
       {:ok, elements} ->
         elements
       {:error, e} ->
-        handle_error(e)
+        cleanup(e)
     end
   end
 
@@ -206,9 +206,9 @@ defmodule Wallaby.Node.Query do
       {:error, {:not_found, _}} ->
         parent
         |> check_for_bad_labels(query)
-        |> handle_error
+        |> cleanup
       {:error, e} ->
-        handle_error(e)
+        cleanup(e)
     end
   end
 
@@ -287,6 +287,10 @@ defmodule Wallaby.Node.Query do
   end
   defp assert_count(elements, query, count) do
     {:error, {:ambiguous, query, elements, count}}
+  end
+
+  defp cleanup(error) do
+    handle_error(error)
   end
 
   defp handle_error({:not_found, locator}) do

--- a/test/wallaby/session/navigation_test.exs
+++ b/test/wallaby/session/navigation_test.exs
@@ -1,0 +1,31 @@
+defmodule Wallaby.Session.NavigationTest do
+  use Wallaby.SessionCase, async: false
+
+  test "navigating by path only", %{session: session, server: server} do
+    Application.put_env(:wallaby, :base_url, server.base_url)
+    session
+    |> visit("page_1.html")
+
+    element =
+      session
+      |> find(".blue")
+
+    assert element
+    Application.put_env(:wallaby, :base_url, nil)
+  end
+
+  test "visit/2 with a relative url and no base url raises exception", %{session: session} do
+    assert_raise(Wallaby.NoBaseUrl, fn ->
+      Application.put_env(:wallaby, :base_url, nil)
+      session
+      |> visit("/page_1.html")
+    end)
+  end
+
+  test "visit/2 with an absolute path does not use the base url", %{session: session, server: server} do
+    session
+    |> visit(server.base_url <> "/page_1.html")
+
+    assert has_css?(session, "#visible")
+  end
+end

--- a/test/wallaby/session/screenshot_test.exs
+++ b/test/wallaby/session/screenshot_test.exs
@@ -1,0 +1,51 @@
+defmodule Wallaby.Session.ScreenshotTest do
+  use Wallaby.SessionCase, async: false
+
+  setup %{server: server, session: session} do
+    page =
+      session
+      |> visit(server.base_url)
+
+    {:ok, page: page}
+  end
+
+  test "taking screenshots", %{page: page} do
+    node =
+      page
+      |> take_screenshot
+      |> find("#header")
+      |> take_screenshot
+
+    screenshots =
+      node
+      |> Map.get(:session)
+      |> Map.get(:screenshots)
+
+    assert Enum.count(screenshots) == 2
+
+    Enum.each(screenshots, fn(path) ->
+      assert File.exists? path
+    end)
+
+    File.rm_rf! "#{File.cwd!}/screenshots"
+  end
+
+  test "users can specify the screenshot directory", %{page: page} do
+    Application.put_env(:wallaby, :screenshot_dir, "shots")
+
+    screenshots =
+      page
+      |> take_screenshot
+      |> Map.get(:screenshots)
+
+    assert screenshots |> Enum.count == 1
+
+    Enum.each screenshots, fn(path) ->
+      assert path =~ ~r/^shots\/(.*)$/
+      assert File.exists? path
+    end
+
+    Application.put_env(:wallaby, :screenshot_dir, nil)
+    File.rm_rf! "#{File.cwd!}/shots"
+  end
+end

--- a/test/wallaby/session/screenshot_test.exs
+++ b/test/wallaby/session/screenshot_test.exs
@@ -48,4 +48,22 @@ defmodule Wallaby.Session.ScreenshotTest do
     Application.put_env(:wallaby, :screenshot_dir, nil)
     File.rm_rf! "#{File.cwd!}/shots"
   end
+
+  test "automatically taking screenshots on failure", %{page: page} do
+    assert_raise Wallaby.ElementNotFound, fn ->
+      find(page, ".some-selector")
+    end
+    refute File.exists?("#{File.cwd!}/screenshots")
+
+    Application.put_env(:wallaby, :screenshot_on_failure, true)
+
+    assert_raise Wallaby.ElementNotFound, fn ->
+      find(page, ".some-selector")
+    end
+    assert File.exists?("#{File.cwd!}/screenshots")
+    assert File.ls!("#{File.cwd!}/screenshots") |> Enum.count == 1
+
+    File.rm_rf! "#{File.cwd!}/screenshots"
+    Application.put_env(:wallaby, :screenshot_on_failure, nil)
+  end
 end

--- a/test/wallaby/session_test.exs
+++ b/test/wallaby/session_test.exs
@@ -1,5 +1,5 @@
 defmodule Wallaby.SessionTest do
-  use Wallaby.SessionCase, async: false
+  use Wallaby.SessionCase, async: true
   use Wallaby.DSL
 
   test "click through to another page", %{server: server, session: session} do
@@ -12,56 +12,6 @@ defmodule Wallaby.SessionTest do
       |> find(".blue")
 
     assert element
-  end
-
-  test "navigating by path only", %{session: session, server: server} do
-    Application.put_env(:wallaby, :base_url, server.base_url)
-    session
-    |> visit("page_1.html")
-
-    element =
-      session
-      |> find(".blue")
-
-    assert element
-    Application.put_env(:wallaby, :base_url, nil)
-  end
-
-  test "visit/2 with a relative url and no base url raises exception", %{session: session, server: _server} do
-    assert_raise(Wallaby.NoBaseUrl, fn ->
-      Application.put_env(:wallaby, :base_url, nil)
-      session
-      |> visit("/page_1.html")
-    end)
-  end
-
-  test "visit/2 with an absolute path does not use the base url", %{session: session, server: server} do
-    session
-    |> visit(server.base_url <> "/page_1.html")
-
-    assert has_css?(session, "#visible")
-  end
-
-  test "taking screenshots", %{session: session, server: server} do
-    node =
-      session
-      |> visit(server.base_url)
-      |> take_screenshot
-      |> find("#header")
-      |> take_screenshot
-
-    screenshots =
-      node
-      |> Map.get(:session)
-      |> Map.get(:screenshots)
-
-    assert Enum.count(screenshots) == 2
-
-    Enum.each(screenshots, fn(path) ->
-      assert File.exists? path
-    end)
-
-    File.rm_rf! "#{File.cwd!}/screenshots"
   end
 
   test "gets the current_url of the session", %{server: server, session: session}  do


### PR DESCRIPTION
Users can now specify the screenshot directory. This should allow for taking screenshots on CI servers. Along with that we can tell Wallaby to automatically take screenshots on any failure.