### PR TITLE
Throw correct error for finding visible elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.2.2
+  - 1.3.1
 otp_release:
   - 18.2.1

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -101,6 +101,30 @@ defmodule Wallaby.InvisibleElement do
   end
 end
 
+defmodule Wallaby.VisibleElement do
+  defexception [:message]
+
+  def exception(locator) do
+    %__MODULE__{message: msg(locator)}
+  end
+
+  def msg({:css, query}) do
+    base_msg("the css", query)
+  end
+  def msg({_, query}) do
+    base_msg("the locator", query)
+  end
+
+  def base_msg(locator, query) do
+    """
+    An element with #{locator}: '#{query}' should not have been visible but was.
+
+    If you expect the element to be visible to the user then you should
+    remove the `visible: false` option from your finder.
+    """
+  end
+end
+
 defmodule Wallaby.BadMetadata do
   defexception [:message]
 end

--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -255,10 +255,14 @@ defmodule Wallaby.Node.Query do
 
   defp assert_visibility(elements, query, visible) when is_list(elements) do
     cond do
-      Enum.all?(elements, &(Node.visible?(&1) == visible)) ->
+      visible && Enum.all?(elements, &(Node.visible?(&1))) ->
         {:ok, elements}
-      true ->
+      !visible && Enum.all?(elements, &(!Node.visible?(&1))) ->
+        {:ok, elements}
+      visible ->
         {:error, {:not_visible, query}}
+      !visible ->
+        {:error, {:visible, query}}
     end
   end
 
@@ -304,6 +308,9 @@ defmodule Wallaby.Node.Query do
   end
   defp handle_error({:found, locator}) do
     raise Wallaby.ElementFound, locator
+  end
+  defp handle_error({:visible, locator}) do
+    raise Wallaby.VisibleElement, locator
   end
   defp handle_error({:not_visible, locator}) do
     raise Wallaby.InvisibleElement, locator

--- a/test/support/pages/page_1.html
+++ b/test/support/pages/page_1.html
@@ -15,6 +15,14 @@
       </ul>
       <p id="visible">Visible</p>
       <p id="invisible" style="display:none">Invisible</p>
+      <p id="off-the-page" style="position:absolute;top:-300px;">Off the page</p>
+      <div style="position:relative;width:100px;height:50px;">
+        <div style="position:absolute;top:0;left:0;right:0;bottom:0;background-color:red;">
+        </div>
+        <div id="obscured">
+          Obscured
+        </div>
+      </div>
       <div id="fixed" style="position:fixed;left:100px;top:100px;width:100px;height:50px">
         Fixed Position
       </div>

--- a/test/wallaby/node/query_test.exs
+++ b/test/wallaby/node/query_test.exs
@@ -38,4 +38,22 @@ defmodule Wallaby.Node.QueryTest do
       find page, {:xpath, "//test-element"}
     end
   end
+
+  test "find/3 finds invisible elements", %{session: session, server: server} do
+    page =
+      session
+      |> visit(server.base_url <> "page_1.html")
+
+    assert find(page, "#invisible", visible: false)
+  end
+
+  test "find/3 throws errors if element should not be visible", %{session: session, server: server} do
+    page =
+      session
+      |> visit(server.base_url <> "page_1.html")
+
+    assert_raise Wallaby.VisibleElement, fn ->
+      find(page, "#visible", visible: false)
+    end
+  end
 end

--- a/test/wallaby/node_test.exs
+++ b/test/wallaby/node_test.exs
@@ -238,19 +238,40 @@ defmodule Wallaby.NodeTest do
     assert find(session, "#visible", count: :any) |> length == 1
   end
 
-  test "visible?/1 determines if the node is visible on the page", %{session: session, server: server} do
+  describe "visible?/1" do
+    setup :visit_page
+
+    test "determines if the node is visible to the user", %{page: page} do
+      page
+      |> find("#visible")
+      |> visible?
+      |> assert
+
+      page
+      |> find("#invisible", visible: false)
+      |> visible?
+      |> refute
+    end
+
+    test "handles elements that are not on the page", %{page: page} do
+      node = find(page, "#off-the-page", visible: false)
+
+      assert visible?(node) == false
+    end
+
+    @tag skip: "Unsuported in phantom"
+    test "handles obscured elements", %{page: page} do
+      node = find(page, "#obscured", visible: false)
+
+      assert visible?(node) == false
+    end
+  end
+
+  def visit_page(%{session: session, server: server}) do
     page =
       session
       |> visit(server.base_url <> "page_1.html")
 
-    page
-    |> find("#visible")
-    |> visible?
-    |> assert
-
-    page
-    |> find("#invisible", visible: false)
-    |> visible?
-    |> refute
+    {:ok, page: page}
   end
 end


### PR DESCRIPTION
If an element should have been invisible but wasn't we still threw the "element is invisible" error which was confusing.