### PR TITLE
Fix so select can work when locator is a label with id

### DIFF
--- a/lib/wallaby/xpath.ex
+++ b/lib/wallaby/xpath.ex
@@ -48,7 +48,7 @@ defmodule Wallaby.XPath do
   Match any `select` by name, id, or label.
   """
   def select(query) do
-    ".//select[(((./@id = '#{query}' or ./@name = '#{query}')) or ./@name = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//select"
+    ".//select[(((./@id = '#{query}' or ./@name = '#{query}')) or ./@name = //label[contains(normalize-space(string(.)), '#{query}')]/@for or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//select"
   end
 
   @doc """

--- a/test/support/pages/select_boxes.html
+++ b/test/support/pages/select_boxes.html
@@ -6,6 +6,7 @@
   <body>
     <h1>Select Boxes</h1>
     <form class="form" action="index.html" method="post">
+      <label for='select-box'>Select With ID</label>
       <select id='select-box'>
         <option id='select-option-1'>Option 1</option>
         <option id='select-option-2'>Option 2</option>

--- a/test/wallaby/dsl/actions/select_test.exs
+++ b/test/wallaby/dsl/actions/select_test.exs
@@ -36,6 +36,15 @@ defmodule Wallaby.Actions.SelectTest do
     assert find(page, "#select-option-5") |> selected?
   end
 
+  test "choosing an option from a select box by label when for is id", %{page: page} do
+    refute find(page, "#select-option-2") |> selected?
+
+    page
+    |> select("Select With ID", option: "Option 2")
+
+    assert find(page, "#select-option-2") |> selected?
+  end
+
   test "throw an error if a label exists but does not have a for attribute", %{page: page} do
     assert_raise Wallaby.BadHTML, fn ->
       select(page, "Select with bad label", option: "Option")


### PR DESCRIPTION
Hello, I noticed that Wallaby can't find options in a select if the locator is a label's text and that label's "for" points to the select id.

This PR adds a test for that case and fixes it :).