### PR TITLE
Return errors if buttons are missing types.

### DIFF
--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -38,17 +38,17 @@ defmodule Wallaby.Driver do
   def find_elements(%Session{base_url: base_url, id: id}=session, query) do
     request(:post, "#{base_url}session/#{id}/elements", to_params(query))
     |> Map.get("value")
-    |> Enum.map(&cast_as_node({session, &1}))
+    |> Enum.map(&cast_as_node({session, &1, query}))
   end
 
   def find_elements(%Node{id: id, session: session}, query) do
     request(:post, "#{session.base_url}session/#{session.id}/element/#{id}/elements", to_params(query))
     |> Map.get("value")
-    |> Enum.map(&cast_as_node({session, &1}))
+    |> Enum.map(&cast_as_node({session, &1, query}))
   end
 
-  defp cast_as_node({session, %{"ELEMENT" => id}}) do
-    %Wallaby.Node{id: id, session: session}
+  defp cast_as_node({session, %{"ELEMENT" => id}, query}) do
+    %Wallaby.Node{id: id, session: session, query: query}
   end
 
   @doc """

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -38,9 +38,9 @@ defmodule Wallaby.ElementNotFound do
   def msg({:fillable_field, query}), do: base_msg("a text input or textarea", query)
   def msg({:checkbox, query}), do: base_msg("a checkbox", query)
   def msg({:radio_button, query}), do: base_msg("a radio button", query)
-  def msg({:button, query}), do: base_msg("a button", query)
   def msg({:link, query}), do: base_msg("a link", query)
   def msg({:xpath, query}), do: base_msg("an element with an xpath", query)
+  def msg({:button, query}), do: base_msg("a button", query)
   def msg({_, query}), do: base_msg("an element", query)
 
   def base_msg(locator, query) do
@@ -171,6 +171,14 @@ defmodule Wallaby.BadHTML do
     doesn't match the id of any #{type(type)}.
 
     Make sure that id on your #{type(type)} is `id="#{for_text}"`.
+    """
+  end
+
+  def msg({:button_with_no_type, {_, button_locator}}) do
+    """
+    The text '#{button_locator}' matched a button but the button has no 'type' attribute.
+
+    You can fix this by including `type="[submit|reset|button|image]"` on the appropriate button.
     """
   end
 

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -3,15 +3,16 @@ defmodule Wallaby.Node do
   Common functionality for interacting with DOM nodes.
   """
 
-  defstruct [:session, :id]
-
-  @type t :: %__MODULE__{
-    session: Session.t,
-    id: String.t
-  }
+  defstruct [:session, :id, :query]
 
   @type locator :: Session.t | t
-  @type query :: String.t | {:xpath, String.t}
+  @type query :: String.t | {atom, String.t}
+  @type t :: %__MODULE__{
+    session: Session.t,
+    id: String.t,
+    query: query
+  }
+
 
   alias __MODULE__
   alias Wallaby.Driver
@@ -240,5 +241,18 @@ defmodule Wallaby.Node do
 
   defp max_wait_time do
     Application.get_env(:wallaby, :max_wait_time, @default_max_wait_time)
+  end
+end
+
+defimpl String.Chars, for: Wallaby.Node do
+  def to_string(node) do
+    stringify_query(node.query)
+  end
+
+  def stringify_query({:css, locator}) do
+    locator
+  end
+  def stringify_query({_, locator}) do
+    locator
   end
 end

--- a/test/support/pages/forms.html
+++ b/test/support/pages/forms.html
@@ -55,6 +55,7 @@
         <label>Checkbox with bad label</label>
         <input type="checkbox" name="checkbox">
       </div>
+      <button>button without type</button>
     </form>
 
     <form class="wait-form" action="index.html" method="post">

--- a/test/wallaby/node/query_test.exs
+++ b/test/wallaby/node/query_test.exs
@@ -56,4 +56,12 @@ defmodule Wallaby.Node.QueryTest do
       find(page, "#visible", visible: false)
     end
   end
+
+  describe "button/3" do
+    test "throws an error if the button does not include a valid type attribute", %{page: page} do
+      assert_raise Wallaby.BadHTML, fn ->
+        Wallaby.Node.Query.button(page, "button without type", [])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Wallaby will now throw an error if a user tries to find a button that doesn't have a type attribute.