### PR TITLE
Document usage of send_keys and KeyCodes

### DIFF
--- a/lib/wallaby/helpers/key_codes.ex
+++ b/lib/wallaby/helpers/key_codes.ex
@@ -1,9 +1,21 @@
 defmodule Wallaby.Helpers.KeyCodes do
+  @moduledoc """
+  Helper utility for converting key atoms into key codes sutiable to send over
+  the wire.
+  """
 
-  def json(keys) do
-    unicode_string = Enum.map(keys, fn(key)-> "\"#{code(key)}\"" end)
-    |> Enum.join(",")
-    "{\"value\": [#{unicode_string}]}"
+  @doc """
+  Encode a list of key codes to a usable json representation.
+  """
+  @spec json(list(atom)) :: String.t
+
+  def json(keys) when is_list(keys) do
+    unicode =
+      keys
+      |> Enum.map(&"\"#{code(&1)}\"")
+      |> Enum.join(",")
+
+    "{\"value\": [#{unicode}]}"
   end
 
   defp code(:null),      do: "\\uE000"
@@ -53,5 +65,4 @@ defmodule Wallaby.Helpers.KeyCodes do
   defp code(:divide),    do: "\\uE029"
 
   defp code(:command),   do: "\\uE03D"
-
 end

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -152,7 +152,16 @@ defmodule Wallaby.Session do
   end
 
   @doc """
-  Sends a list of key strokes to active element
+  Sends a list of key strokes to active element. Keys should be provided as a
+  list of atoms, which are automatically converted into the corresponding key
+  codes.
+
+  For a list of available key codes see `Wallaby.Helpers.KeyCodes`.
+
+  ## Example
+
+      iex> Wallaby.Session.send_keys(session, [:enter])
+      iex> Wallaby.Session.send_keys(session, [:shift, :enter])
   """
   @spec send_keys(t, list(atom)) :: t
 

--- a/test/wallaby/helpers/key_codes_test.exs
+++ b/test/wallaby/helpers/key_codes_test.exs
@@ -1,8 +1,10 @@
 defmodule Wallaby.Helpers.KeyCodesTest do
   use ExUnit.Case, async: true
+
   import Wallaby.Helpers.KeyCodes
 
   test "encoding unicode values" do
     assert json([:enter]) == "{\"value\": [\"\\uE007\"]}"
+    assert json([:shift, :enter]) == "{\"value\": [\"\\uE008\",\"\\uE007\"]}"
   end
 end


### PR DESCRIPTION
I ran into the need to send an `enter` key as part of an acceptance test. There wasn't any documentation within `Session.send_keys/2` about how it worked or how keys should be defined. This is a basic attempt at adding documentation to highlight that key code conversion if a feature, and hopefully lead future devs to the right part of the source code.