### PR TITLE
Allow numbers to be passed to fill_in

### DIFF
--- a/lib/wallaby/dsl/actions.ex
+++ b/lib/wallaby/dsl/actions.ex
@@ -63,6 +63,9 @@ defmodule Wallaby.DSL.Actions do
 
     parent
   end
+  def fill_in(parent, locator, [with: value]=opts) when is_number(value) do
+    fill_in(parent, locator,  Keyword.merge(opts, [with: to_string(value)]))
+  end
 
   @doc """
   Chooses a radio button based on id, label text, or name.

--- a/test/support/pages/forms.html
+++ b/test/support/pages/forms.html
@@ -9,7 +9,7 @@
       <label for="name">Name</label>
       <input id="name_field" type="text" name="name" value="">
       <input id="email_field" type="email" name="email" value="">
-      <input type="password" name="password" value="">
+      <input id="password_field" type="password" name="password" value="">
 
       <label>
         <input type="checkbox" id="checkbox1" value="" name="testbox">

--- a/test/wallaby/dsl/actions/fill_in_test.exs
+++ b/test/wallaby/dsl/actions/fill_in_test.exs
@@ -23,6 +23,13 @@ defmodule Wallaby.Actions.FillInTest do
     assert find(page, "#name_field") |> has_value?("Chris")
   end
 
+  test "fill_in accepts numbers", %{page: page} do
+    page
+    |> fill_in("password", with: 1234)
+
+    assert find(page, "#password_field") |> has_value?("1234")
+  end
+
   test "filling in multiple inputs", %{page: page} do
     page
     |> fill_in("name", with: "Alex")


### PR DESCRIPTION
Fill in throws an error is the input isn't a string. This allows fill_in to accept numbers and convert them into binaries before filling in the field.