### PR TITLE
Set HTTPoison recv timeout to infinity

### DIFF
--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -295,7 +295,7 @@ defmodule Wallaby.Driver do
 
   defp make_request(method, url, body) do
     headers = [{"Content-Type", "text/json"}]
-    case HTTPoison.request(method, url, body, headers, [timeout: :infinity]) do
+    case HTTPoison.request(method, url, body, headers, [timeout: :infinity, recv_timeout: :infinity]) do
       {:ok, response} ->
         Poison.decode!(response.body)
       {:error, e} ->


### PR DESCRIPTION
This fixes the issue with httpoison timeouts and instead lets Wallaby handle
the timeouts explicitly.

Closes #74.