### PR TITLE
Fix issue with disabling js-errors

### DIFF
--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -48,12 +48,16 @@ defmodule Wallaby do
   end
 
   def js_errors? do
-    Application.get_env(:wallaby, :js_errors) || true
+    Application.get_env(:wallaby, :js_errors)
+    |> explicitly_set()
   end
 
   def phantomjs_path do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end
+
+  defp explicitly_set(:false), do: false
+  defp explicitly_set(_), do: true
 
   defp poolboy_config do
     [name: {:local, @pool_name},

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -48,16 +48,12 @@ defmodule Wallaby do
   end
 
   def js_errors? do
-    Application.get_env(:wallaby, :js_errors)
-    |> explicitly_set()
+    Application.get_env(:wallaby, :js_errors, true)
   end
 
   def phantomjs_path do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end
-
-  defp explicitly_set(:false), do: false
-  defp explicitly_set(_), do: true
 
   defp poolboy_config do
     [name: {:local, @pool_name},

--- a/test/wallaby/driver/configuration_test.exs
+++ b/test/wallaby/driver/configuration_test.exs
@@ -1,0 +1,14 @@
+defmodule Wallaby.Driver.ConfigurationTest do
+  use Wallaby.SessionCase, async: false
+
+  test "js errors can be disabled", %{session: session, server: server} do
+    Application.put_env(:wallaby, :js_errors, false)
+
+    session
+    |> visit(server.base_url <> "/errors.html")
+    |> click_on("Throw an Error")
+    |> assert
+
+    Application.put_env(:wallaby, :js_errors, nil)
+  end
+end

--- a/test/wallaby/driver/js_errors_test.exs
+++ b/test/wallaby/driver/js_errors_test.exs
@@ -1,4 +1,4 @@
-defmodule Wallaby.DriverTest do
+defmodule Wallaby.Driver.JSErrorsTest do
   use Wallaby.SessionCase, async: true
 
   import ExUnit.CaptureIO


### PR DESCRIPTION
It was impossible to disable javascript errors being re-thrown in Wallaby because we were using `||` instead of the default value in `Application.get_env/3`. This PR fixes that issue.