### PR TITLE
Increases gen_server:call timeout to :infinity

### DIFF
--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -31,7 +31,7 @@ defmodule Wallaby do
   end
 
   def start_session(opts \\ []) do
-    server = :poolboy.checkout(@pool_name)
+    server = :poolboy.checkout(@pool_name, true, :infinity)
     Wallaby.Driver.create(server, opts)
   end
 

--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Server do
   end
 
   def get_base_url(server) do
-    GenServer.call(server, :get_base_url)
+    GenServer.call(server, :get_base_url, :infinity)
   end
 
   def init(_) do


### PR DESCRIPTION
Increases timeout from 5000ms to :infinity. In
environments with a low pool size, e.g. CI workers
and lesser powered laptops, test failures due to a
delay > 5000ms in checking out a worker from the
pool frequently occur. As ExUnit has a default max
time for a test case to complete (60_000ms), it
makes sense to avoid these failures by allowing
a test to block until a worker is checked back in
to the pool.