### PR TITLE
Incorrect logic for finding buttons with missing types

### DIFF
--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -286,7 +286,7 @@ defmodule Wallaby.Node.Query do
       |> all("button", [])
 
     cond do
-      Enum.any?(buttons, &(missing_button_type?(&1) && matching_text?(&1, locator))) ->
+      Enum.any?(buttons, &(matching_text?(&1, locator))) ->
         add_error(query, :button_with_no_type)
       true ->
         query
@@ -309,12 +309,6 @@ defmodule Wallaby.Node.Query do
       true  ->
         add_error(query, :not_found)
     end
-  end
-
-  defp missing_button_type?(node) do
-    valid_button_types = ~w(submit reset button image)
-    type = Node.attr(node, "type")
-    Enum.member?(valid_button_types, type)
   end
 
   defp missing_for?(node) do

--- a/test/support/pages/forms.html
+++ b/test/support/pages/forms.html
@@ -62,7 +62,8 @@
         <label>File field with bad label</label>
         <input type="file" name="unlabelled-file">
       </div>
-      <button>button without type</button>
+      <button type="other">button with bad type</button>
+      <button>button with no type</button>
     </form>
 
     <form class="wait-form" action="index.html" method="post">

--- a/test/support/pages/wait.html
+++ b/test/support/pages/wait.html
@@ -20,7 +20,7 @@
         addElement("main")
 
         for (i = 0; i < 5; i++) { addElement("orange") }
-      }, 400)
+      }, 700)
     </script>
   </body>
 </html>

--- a/test/wallaby/dsl/actions/click_button_test.exs
+++ b/test/wallaby/dsl/actions/click_button_test.exs
@@ -217,9 +217,24 @@ defmodule Wallaby.DSL.Actions.ClickButtonTest do
     assert click_on(page, "Hidden Button")
   end
 
+  test "throws an error if the button is missing the type attribute", %{page: page} do
+    msg = Wallaby.QueryError.error_message(:button_with_no_type, %{locator: {:button, "button with no type"}})
+    assert_raise Wallaby.QueryError, msg, fn ->
+      click_button(page, "button with no type", [])
+    end
+  end
+
   test "throws an error if the button does not include a valid type attribute", %{page: page} do
-    assert_raise Wallaby.QueryError, fn ->
-      click_button(page, "button without type", [])
+    msg = Wallaby.QueryError.error_message(:button_with_no_type, %{locator: {:button, "button with bad type"}})
+    assert_raise Wallaby.QueryError, msg, fn ->
+      click_button(page, "button with bad type", [])
+    end
+  end
+
+  test "throws an error if the button cannot be found on the page", %{page: page} do
+    msg = Wallaby.QueryError.error_message(:not_found, %{locator: {:button, "unfound button"}, conditions: [count: 1, visible: true]})
+    assert_raise Wallaby.QueryError, msg, fn ->
+      click_button(page, "unfound button", [])
     end
   end
 end


### PR DESCRIPTION
The logic for finding incorrect buttons was incorrect. This PR adds better tests and fixes the broken logic. Specifically buttons with no type attribute or an invalid type attribute will always return `submit` as their type. To get around this we simply check to see that there is a button that could have matched and then skip any type checking on the button element itself.