### PR TITLE
Fix text filtering

### DIFF
--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -316,7 +316,7 @@ defmodule Wallaby.Node.Query do
   end
 
   defp matching_text?(node, locator) do
-    Node.text(node) == locator
+    Node.text(node) =~ ~r/#{Regex.escape(locator)}/
   end
 
   defp assert_text(%Query{result: nodes, conditions: opts}=query) do

--- a/test/support/pages/page_1.html
+++ b/test/support/pages/page_1.html
@@ -49,5 +49,16 @@
         Fixed Position
       </div>
     </div>
+
+    <div class="inner-text">
+      <p>
+        Inner Text
+      </p>
+      <p>
+        More inner text
+      </p>
+    </div>
+
+    <p class="plus-one">+ 1</p>
   </body>
 </html>

--- a/test/wallaby/dsl/finders/find_test.exs
+++ b/test/wallaby/dsl/finders/find_test.exs
@@ -52,6 +52,15 @@ defmodule Wallaby.DSL.Finders.FindTest do
       assert user1 != user2
     end
 
+    test "can be scoped by inner text when there are multiple elements with text", %{page: page} do
+      element = find(page, ".inner-text", text: "Inner Text")
+      assert element
+    end
+
+    test "scoping with text escapes the text", %{page: page} do
+      assert find(page, ".plus-one", text: "+ 1")
+    end
+
     test "scopes can be composed together", %{page: page} do
       assert find(page, ".user", text: "Same User", count: 2)
       assert find(page, ".user", text: "Visible User", visible: true)


### PR DESCRIPTION
Text filtering needs to use a regex match instead of a string. That way if there is other text inside of the element we can still provide scoping