### PR TITLE
Escape xpath quotes

### DIFF
--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -85,7 +85,7 @@ defmodule Wallaby.Node.Query do
     %__MODULE__{
       parent: parent,
       locator: locator,
-      query: build_locator(locator),
+      query: locator |> build_locator,
       conditions: build_conditions(opts),
     }
   end
@@ -251,10 +251,20 @@ defmodule Wallaby.Node.Query do
       {:ok, elements} ->
         elements
       {:error, query} ->
-        query
-        |> check_for_bad_html
-        |> handle_error
+        if not_found?(query) do
+          query
+          |> check_for_bad_html
+          |> handle_error
+        else
+          query
+          |> handle_error
+        end
     end
+  end
+
+  defp not_found?(query) do
+    query.errors
+    |> Enum.any?(& &1 == :not_found)
   end
 
   defp find_element(parent, locator, opts) do

--- a/lib/wallaby/xpath.ex
+++ b/lib/wallaby/xpath.ex
@@ -11,21 +11,21 @@ defmodule Wallaby.XPath do
   https://github.com/jnicklas/xpath/blob/master/lib/xpath/html.rb
   """
   def link(lnk) do
-    ".//a[./@href][(((./@id = '#{lnk}' or contains(normalize-space(string(.)), '#{lnk}')) or contains(./@title, '#{lnk}')) or .//img[contains(./@alt, '#{lnk}')])]"
+    ~s{.//a[./@href][(((./@id = "#{lnk}" or contains(normalize-space(string(.)), "#{lnk}")) or contains(./@title, "#{lnk}")) or .//img[contains(./@alt, "#{lnk}")])]}
   end
 
   @doc """
   Match any clickable buttons
   """
   def button(query) do
-    ".//*[self::input | self::button][(./@type = 'submit' or ./@type = 'reset' or ./@type = 'button' or ./@type = 'image')][(((./@id = '#{query}' or ./@name = '#{query}' or ./@value = '#{query}' or ./@alt = '#{query}' or ./@title = '#{query}' or contains(normalize-space(string(.)), '#{query}'))))]"
+    ~s{.//*[self::input | self::button][(./@type = 'submit' or ./@type = 'reset' or ./@type = 'button' or ./@type = 'image')][(((./@id = "#{query}" or ./@name = "#{query}" or ./@value = "#{query}" or ./@alt = "#{query}" or ./@title = "#{query}" or contains(normalize-space(string(.)), "#{query}"))))]}
   end
 
   @doc """
   Match any radio buttons
   """
   def radio_button(query) do
-    ".//input[./@type = 'radio'][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//input[./@type = 'radio']"
+    ~s{.//input[./@type = 'radio'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "radio"]}
   end
 
   @doc """
@@ -34,34 +34,34 @@ defmodule Wallaby.XPath do
   `hidden`, or `file`.
   """
   def fillable_field(query) when is_binary(query) do
-    ".//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]"
+    ~s{.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]}
   end
 
   @doc """
   Match any checkboxes
   """
   def checkbox(query) do
-    ".//input[./@type = 'checkbox'][(((./@id = '#{query}' or ./@name = '#{query}') or ./@placeholder = '#{query}') or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//input[./@type = 'checkbox']"
+    ~s{.//input[./@type = 'checkbox'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "checkbox"]}
   end
 
   @doc """
   Match any `select` by name, id, or label.
   """
   def select(query) do
-    ".//select[(((./@id = '#{query}' or ./@name = '#{query}')) or ./@name = //label[contains(normalize-space(string(.)), '#{query}')]/@for or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//select"
+    ~s{.//select[(((./@id = "#{query}" or ./@name = "#{query}")) or ./@name = //label[contains(normalize-space(string(.)), "#{query}")]/@for or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//select}
   end
 
   @doc """
   Match any `option` by visible text
   """
   def option(query) do
-    ".//option[normalize-space(text())='#{query}']"
+    ~s{.//option[normalize-space(text())="#{query}"]}
   end
 
   @doc """
   Matches any file field by name, id, or label
   """
   def file_field(query) do
-    ".//input[./@type = 'file'][(((./@id = '#{query}' or ./@name = '#{query}')) or ./@id = //label[contains(normalize-space(string(.)), '#{query}')]/@for)] | .//label[contains(normalize-space(string(.)), '#{query}')]//.//input[./@type = 'file']"
+    ~s{.//input[./@type = 'file'][(((./@id = "#{query}" or ./@name = "#{query}")) or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = 'file']}
   end
 end

--- a/test/support/pages/forms.html
+++ b/test/support/pages/forms.html
@@ -12,7 +12,7 @@
       <input id="password_field" type="password" name="password" value="">
 
       <label for="file_field">File</label>
-      <input id="file_field" type="file" name="file">
+      <input id="file_field" type="file" name="file_input">
 
       <label>
         <input type="checkbox" id="checkbox1" value="" name="testbox">
@@ -90,6 +90,26 @@
           <button type="button" name="button">Hidden Button</button>
         </div>
       </div>
+    </form>
+
+    <form class="escape-characters">
+      <label for="escape_name_field">I'm a text field</label>
+      <input id="escape_name_field" type="text" name="escape_name" value="">
+
+      <label for="escape_file">I'm a file field</label>
+      <input id="escape_file" type="file" name="escape_file">
+
+      <label>
+        <input type="checkbox" id="escape-checkbox" value="" name="escapebox">
+        I'm a checkbox
+      </label>
+
+      <label>
+        <input type="radio" id="escape-radio" name="escaperadio" value="escape-option-1">
+        I'm a radio button
+      </label>
+
+      <button type="button" name="button">I'm a button</button>
     </form>
 
     <script>

--- a/test/support/pages/select_boxes.html
+++ b/test/support/pages/select_boxes.html
@@ -24,6 +24,11 @@
       <select name="select-with-bad-label">
         <option>Option</option>
       </select>
+
+      <label for='escape-select'>I'm a select</label>
+      <select name="escape-select">
+        <option>I'm an option</option>
+      </select>
     </form>
   </body>
 </html>

--- a/test/wallaby/dsl/actions/check_test.exs
+++ b/test/wallaby/dsl/actions/check_test.exs
@@ -71,4 +71,8 @@ defmodule Wallaby.DSL.Actions.CheckTest do
   test "waits until the checkbox appears", %{page: page} do
     assert check(page, "Hidden Checkbox")
   end
+
+  test "escapes quotes", %{page: page} do
+    assert check(page, "I'm a checkbox")
+  end
 end

--- a/test/wallaby/dsl/actions/choose_test.exs
+++ b/test/wallaby/dsl/actions/choose_test.exs
@@ -53,4 +53,8 @@ defmodule Wallaby.Actions.ChooseTest do
   test "waits until the radio button appears", %{page: page} do
     assert choose(page, "Hidden Radio Button")
   end
+
+  test "escape quotes", %{page: page} do
+    assert choose(page, "I'm a radio button")
+  end
 end

--- a/test/wallaby/dsl/actions/click_button_test.exs
+++ b/test/wallaby/dsl/actions/click_button_test.exs
@@ -237,4 +237,8 @@ defmodule Wallaby.DSL.Actions.ClickButtonTest do
       click_button(page, "unfound button", [])
     end
   end
+
+  test "escapes quotes", %{page: page} do
+    assert click_on(page, "I'm a button")
+  end
 end

--- a/test/wallaby/dsl/actions/file_test.exs
+++ b/test/wallaby/dsl/actions/file_test.exs
@@ -12,7 +12,7 @@ defmodule Wallaby.Actions.FileTest do
   describe "attaching a file to a form" do
     test "by name", %{page: page} do
       page
-      |> attach_file("file", path: "test/support/fixtures/file.txt")
+      |> attach_file("file_input", path: "test/support/fixtures/file.txt")
 
       assert find(page, "#file_field") |> has_value?("C:\\fakepath\\file.txt")
     end
@@ -44,5 +44,9 @@ defmodule Wallaby.Actions.FileTest do
     assert_raise Wallaby.QueryError, msg, fn ->
       attach_file(page, "File field with bad label", path: "test/support/fixtures/file.txt")
     end
+  end
+
+  test "escapes quotes", %{page: page} do
+    assert attach_file(page, "I'm a file field", path: "test/support/fixtures/file.txt")
   end
 end

--- a/test/wallaby/dsl/actions/fill_in_test.exs
+++ b/test/wallaby/dsl/actions/fill_in_test.exs
@@ -64,4 +64,8 @@ defmodule Wallaby.Actions.FillInTest do
       fill_in(page, "Input with bad id", with: "Test")
     end
   end
+
+  test "escapes quotes", %{page: page} do
+    assert fill_in(page, "I'm a text field", with: "Stuff")
+  end
 end

--- a/test/wallaby/dsl/actions/select_test.exs
+++ b/test/wallaby/dsl/actions/select_test.exs
@@ -58,4 +58,8 @@ defmodule Wallaby.Actions.SelectTest do
 
     assert select(page, "Hidden Select", option: "Option")
   end
+
+  test "escapes quotes", %{page: page} do
+    assert select(page, "I'm a select", option: "I'm an option")
+  end
 end


### PR DESCRIPTION
Switching to double quotes so that single quotes can be used in xpath queries. In the future this should be solved more completely by using xpath concatenation.