### PR TITLE
Separate local storage per phantom

### DIFF
--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -5,6 +5,10 @@ defmodule Wallaby.Server do
     GenServer.start_link(__MODULE__, [])
   end
 
+  def stop(server) do
+    GenServer.stop(server)
+  end
+
   def get_base_url(server) do
     GenServer.call(server, :get_base_url, :infinity)
   end

--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -84,4 +84,8 @@ defmodule Wallaby.Server do
   def handle_call(:get_local_storage_dir, _from, state) do
     {:reply, state.local_storage, state}
   end
+
+  def terminate(_reason, state) do
+    File.rm_rf(state.local_storage)
+  end
 end

--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -13,6 +13,10 @@ defmodule Wallaby.Server do
     GenServer.call(server, :get_local_storage_dir, :infinity)
   end
 
+  def clear_local_storage(server) do
+    GenServer.call(server, :clear_local_storage, :infinity)
+  end
+
   def init(_) do
     port = find_available_port
     local_storage = tmp_local_storage
@@ -83,6 +87,12 @@ defmodule Wallaby.Server do
 
   def handle_call(:get_local_storage_dir, _from, state) do
     {:reply, state.local_storage, state}
+  end
+
+  def handle_call(:clear_local_storage, _from, state) do
+    result = File.rm_rf(state.local_storage)
+
+    {:reply, result, state}
   end
 
   def terminate(_reason, state) do

--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -9,16 +9,21 @@ defmodule Wallaby.Server do
     GenServer.call(server, :get_base_url, :infinity)
   end
 
-  def init(_) do
-    port = find_available_port
-
-    Port.open({:spawn, phantomjs_command(port)}, [:binary, :stream, :use_stdio, :exit_status])
-
-    {:ok, %{running: false, awaiting_url: [], base_url: "http://localhost:#{port}/"}}
+  def get_local_storage_dir(server) do
+    GenServer.call(server, :get_local_storage_dir, :infinity)
   end
 
-  def phantomjs_command(port) do
-    "#{script_path} #{phantomjs_path} --webdriver=#{port} #{args}"
+  def init(_) do
+    port = find_available_port
+    local_storage = tmp_local_storage
+
+    Port.open({:spawn, phantomjs_command(port, local_storage)}, [:binary, :stream, :use_stdio, :exit_status])
+
+    {:ok, %{running: false, awaiting_url: [], base_url: "http://localhost:#{port}/", local_storage: local_storage}}
+  end
+
+  def phantomjs_command(port, local_storage) do
+    "#{script_path} #{phantomjs_path} --webdriver=#{port} --local-storage-path #{local_storage} #{args}"
   end
 
   defp find_available_port do
@@ -26,6 +31,16 @@ defmodule Wallaby.Server do
     {:ok, port} = :inet.port(listen)
     :gen_tcp.close(listen)
     port
+  end
+
+  defp tmp_local_storage do
+    dirname = Integer.to_string(:rand.uniform(0x100000000), 36) |> String.downcase
+
+    local_storage = Path.join(System.tmp_dir!, dirname)
+
+    File.mkdir_p(local_storage)
+
+    local_storage
   end
 
   defp script_path do
@@ -64,5 +79,9 @@ defmodule Wallaby.Server do
 
   def handle_call(:get_base_url, _from, state) do
     {:reply, state.base_url, state}
+  end
+
+  def handle_call(:get_local_storage_dir, _from, state) do
+    {:reply, state.local_storage, state}
   end
 end

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Phantom.ConfigrationTest do
     end
 
     test "updates the phantomjs command" do
-      assert Wallaby.Server.phantomjs_command(1234) =~ ~r/test\/path\/phantomjs/
+      assert Wallaby.Server.phantomjs_command(1234, '/tmp/dir') =~ ~r/test\/path\/phantomjs/
     end
   end
 end

--- a/test/wallaby/server_test.exs
+++ b/test/wallaby/server_test.exs
@@ -29,4 +29,12 @@ defmodule Wallaby.ServerTest do
 
     assert local_storage != other_local_storage
   end
+
+  test "it cleans up the local storage directory properly", %{server: server}  do
+    local_storage = Server.get_local_storage_dir(server)
+    assert File.exists?(local_storage)
+
+    Server.stop(server)
+    refute File.exists?(local_storage)
+  end
 end

--- a/test/wallaby/server_test.exs
+++ b/test/wallaby/server_test.exs
@@ -30,7 +30,15 @@ defmodule Wallaby.ServerTest do
     assert local_storage != other_local_storage
   end
 
-  test "it cleans up the local storage directory properly", %{server: server}  do
+  test "it clears local storage properly", %{server: server} do
+    local_storage = Server.get_local_storage_dir(server)
+    assert File.exists?(local_storage)
+
+    Server.clear_local_storage(server)
+    refute File.exists?(local_storage)
+  end
+
+  test "it cleans up the local storage directory properly", %{server: server} do
     local_storage = Server.get_local_storage_dir(server)
     assert File.exists?(local_storage)
 

--- a/test/wallaby/server_test.exs
+++ b/test/wallaby/server_test.exs
@@ -3,8 +3,30 @@ defmodule Wallaby.ServerTest do
 
   alias Wallaby.Server
 
-  test "it can start a server" do
+  setup do
     {:ok, server} = Server.start_link([])
+
+    local_storage = Server.get_local_storage_dir(server)
+    on_exit fn ->
+      File.rm_rf(local_storage)
+    end
+
+    {:ok, server: server}
+  end
+
+  test "it can start a server", %{server: server}  do
     assert Server.get_base_url(server) =~ ~r"http://localhost:\d+/"
+  end
+
+  test "separate servers do not share local storage", %{server: server} do
+    {:ok, other_server} = Server.start_link([])
+
+    local_storage = Server.get_local_storage_dir(server)
+    other_local_storage = Server.get_local_storage_dir(other_server)
+
+    # Remove the other directory before asserting so we can ensure deletion is successful
+    File.rm_rf(other_local_storage)
+
+    assert local_storage != other_local_storage
   end
 end


### PR DESCRIPTION
To better isolate tests, I thought it would be a good idea for each PhantomJS process to have its own local storage directory. 