### PR TITLE
Ensure that local storage isn't shared across sessions.

### DIFF
--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -35,7 +35,8 @@ defmodule Wallaby do
     Wallaby.Driver.create(server, opts)
   end
 
-  def end_session(%Wallaby.Session{server: server}) do
+  def end_session(%Wallaby.Session{server: server}=session) do
+    :ok = Wallaby.Session.delete(session)
     :poolboy.checkin(Wallaby.ServerPool, server)
   end
 

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -41,6 +41,13 @@ defmodule Wallaby.Driver do
   end
 
   @doc """
+  Deletes a session with the driver.
+  """
+  def delete(session) do
+    request(:delete, session.session_url, %{})
+  end
+
+  @doc """
   Finds an element on the page for a session. If an element is provided then
   the query will be scoped to within that element.
   """

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Phantom do
 
   def default_capabilities do
     %{
-      javascriptEnabled: false,
+      javascriptEnabled: true,
       loadImages: false,
       version: "",
       rotatable: false,

--- a/lib/wallaby/server.ex
+++ b/lib/wallaby/server.ex
@@ -31,7 +31,7 @@ defmodule Wallaby.Server do
   end
 
   def phantomjs_command(port, local_storage) do
-    "#{script_path} #{phantomjs_path} --webdriver=#{port} --local-storage-path #{local_storage} #{args}"
+    "#{script_path} #{phantomjs_path} --webdriver=#{port} --local-storage-path=#{local_storage} #{args}"
   end
 
   defp find_available_port do

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -50,6 +50,17 @@ defmodule Wallaby.Session do
   defstruct [:id, :url, :session_url, :server, screenshots: []]
 
   @doc """
+  Deletes a session.
+  """
+  @spec delete(t) :: :ok
+
+  def delete(session) do
+    Driver.execute_script(session, "localStorage.clear()")
+    Driver.delete(session)
+    :ok
+  end
+
+  @doc """
   Changes the current page to the provided route.
   Relative paths are appended to the provided base_url.
   Absolute paths do not use the base_url.

--- a/test/wallaby/integration/local_storage_test.exs
+++ b/test/wallaby/integration/local_storage_test.exs
@@ -1,0 +1,51 @@
+defmodule Wallaby.Integration.LocalStorageTest do
+  use ExUnit.Case, async: false
+
+  use Wallaby.DSL
+
+  @get_value_script "return localStorage.getItem('test')"
+  @set_value_script "localStorage.setItem('test', 'foo')"
+
+  setup_all _tags do
+    {:ok, server} = Wallaby.TestServer.start
+
+    on_exit fn ->
+      Wallaby.TestServer.stop(server)
+    end
+
+    {:ok, %{server: server}}
+  end
+
+  @tag :focus
+  test "local storage is not shared between sessions", %{server: server} do
+
+    # Checkout all sessions
+    {:ok, session}  = Wallaby.start_session
+    {:ok, s2}       = Wallaby.start_session
+    {:ok, s3}       = Wallaby.start_session
+
+    session
+    |> visit(server.base_url <> "index.html")
+    |> execute_script(@set_value_script)
+
+    assert session
+    |> execute_script(@get_value_script) == "foo"
+
+    assert s2
+    |> visit(server.base_url <> "index.html")
+    |> execute_script(@get_value_script) == nil
+
+    assert s3
+    |> visit(server.base_url <> "index.html")
+    |> execute_script(@get_value_script) == nil
+
+    Wallaby.end_session(session)
+    {:ok, new_session} = Wallaby.start_session
+
+    assert session.server == new_session.server
+
+    assert new_session
+    |> visit(server.base_url <> "index.html")
+    |> execute_script(@get_value_script) == nil
+  end
+end


### PR DESCRIPTION
Local Storage was being shared across sessions because it wasn't being cleared when a session was closed.