### PR TITLE
Add wait_until

### DIFF
--- a/lib/wallaby/dsl/actions.ex
+++ b/lib/wallaby/dsl/actions.ex
@@ -183,4 +183,23 @@ defmodule Wallaby.DSL.Actions do
 
     parent
   end
+
+  # @doc """
+  # Waits until the provided query is satisfied
+  #
+  # ## Examples
+  # ```
+  # session
+  #   |> click_on("Some Button that fires async action")
+  #   |> wait_until(& find(&1, ".result-of-async-action"))
+  # ```
+  # ```
+  # session
+  #   |> click_on("Some Button that fires async action")
+  #   |> wait_until(& link(&1, "Added by async action"))
+  # ```
+  def wait_until(parent, fun) do
+    fun.(parent)
+    parent
+  end
 end

--- a/test/support/pages/wait_until.html
+++ b/test/support/pages/wait_until.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Wait until ...</title>
+
+    <script type="text/html" id="template">
+      <div class="main">
+        <div class="orange">orange</div>
+        <a id="link" href="#">a link</a>
+      </div>
+    </script>
+
+    <script type="text/javascript">
+      setTimeout(function() {
+        var template = document.getElementById("template").innerHTML;
+        document.body.innerHTML = template;
+      }, 700)
+    </script>
+  </head>
+
+  <body>
+  </body>
+</html>

--- a/test/wallaby/dsl/actions/wait_until_test.exs
+++ b/test/wallaby/dsl/actions/wait_until_test.exs
@@ -1,0 +1,27 @@
+defmodule Wallaby.Actions.WaitUntilTest do
+  use Wallaby.SessionCase, async: true
+  use Wallaby.DSL
+  alias Wallaby.Node.Query
+
+  test "wait until `find` is satisfied", %{server: server, session: session} do
+    updated_session =
+      session
+        |> visit(server.base_url <> "wait_until.html")
+        |> wait_until(& find(&1, ".main"))
+
+    assert has_css?(updated_session, ".main"), "waited until selector became present"
+    assert has_css?(updated_session, "html"), "has not narrowed scope"
+  end
+
+  test "wait until `Query.link` is satisfied", %{server: server, session: session} do
+    updated_session =
+      session
+        |> visit(server.base_url <> "wait_until.html")
+        |> wait_until(& Query.link(&1, "a", text: "a link"))
+
+    html_root = updated_session |> find("body")
+
+    assert has_text?(html_root, "a link"), "waited until text became present"
+    assert has_css?(updated_session, "html"), "has not narrowed scope"
+  end
+end


### PR DESCRIPTION
@keathley so it wasn't until I got to the documentation that nagging doubts I had about this approach gave me pause for thought...

Seeing as Wallaby already has a bunch of finder functions the logical endpoint for this approach is another set of functions that all do the same thing, except they return the original session instead of the session with the narrowed scope. 

Ideally this would be handled with currying e.g.

```
      session
        |> visit(server.base_url <> "wait.html")
        |> wait_until(find(".main"))
```

or

```
      session
        |> visit(server.base_url <> "wait.html")
        |> wait_until(link("Home"))
```

I'll try and get some feedback regarding design and see if there's a better approach. 
