### PR TITLE
Update key_codes.ex

### DIFF
--- a/lib/wallaby/helpers/key_codes.ex
+++ b/lib/wallaby/helpers/key_codes.ex
@@ -32,7 +32,7 @@ defmodule Wallaby.Helpers.KeyCodes do
   defp code(:pause),     do: "\\uE00B"
   defp code(:escape),    do: "\\uE00C"
 
-  defp code(:space),       do: "\\eE00D"
+  defp code(:space),       do: "\\uE00D"
   defp code(:pageup),      do: "\\uE00E"
   defp code(:pagedown),    do: "\\uE00F"
   defp code(:end),         do: "\\uE010"


### PR DESCRIPTION
Correct typo on :space keycode. I double checked the keycode against https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html