### PR TITLE
Allow js logs to be disabled or redirected to a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,13 +248,18 @@ session
 |> find(".async-result")
 ```
 
-### Logging and errors
+### Javascript logging and errors
 
 Wallaby captures both javascript logs and errors. Any uncaught exceptions in javascript will be re-thrown in elixir. This can be disabled by specifying `js_errors: false` in your Wallaby config.
 
-## Future Work
+Javascript logs are written to :stdio by default. This can be changed to any IO device by setting the `:js_logger` option in your wallaby config. For instance if you want to write all Javascript console logs to a file you could do something like this:
 
-* Support other drivers (such as Selenium)
+```elixir
+{:ok, file} = File.open("browser_logs.log", [:write])
+Application.put_env(:wallaby, :js_logger, file)
+```
+
+Logging can be disabled by setting `:js_logger` to `nil`.
 
 ## Contributing
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,8 @@ use Mix.Config
 
 config :wallaby,
   max_wait_time: 1000,
-  pool_size: 3
+  pool_size: 3,
+  js_logger: :stdio
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -11,6 +11,7 @@ defmodule Wallaby do
   * `:screenshot_on_failure` - if Wallaby should take screenshots on test failures (defaults to `false`).
   * `:max_wait_time` - The amount of time that Wallaby should wait to find an element on the page. (defaults to `3_000`)
   * `:js_errors` - if Wallaby should re-throw javascript errors in elixir (defaults to true).
+  * `:js_logger` - IO device where javascript console logs are written to. Defaults to :stdio. This option can also be set to a file or any other io device. You can disable javascript console logging by setting this to `nil`.
   * `:phantomjs` - The path to the phantomjs executable (defaults to "phantomjs")
   * `:phantomjs_args` - Any extra arguments that should be passed to phantomjs (defaults to "")
   """
@@ -50,6 +51,10 @@ defmodule Wallaby do
 
   def js_errors? do
     Application.get_env(:wallaby, :js_errors, true)
+  end
+
+  def js_logger do
+    Application.get_env(:wallaby, :js_logger, :stdio)
   end
 
   def phantomjs_path do

--- a/lib/wallaby/phantom/logger.ex
+++ b/lib/wallaby/phantom/logger.ex
@@ -13,9 +13,10 @@ defmodule Wallaby.Phantom.Logger do
   end
 
   def parse_log(%{"level" => "INFO", "message" => msg}) do
-    @line_number_regex
-    |> Regex.replace(msg, "")
-    |> IO.puts()
+    if Wallaby.js_logger do
+      msg = Regex.replace(@line_number_regex, msg, "")
+      IO.puts(Wallaby.js_logger, msg)
+    end
   end
 
   def parse_log(_), do: nil

--- a/test/wallaby/phantom/logger_test.exs
+++ b/test/wallaby/phantom/logger_test.exs
@@ -1,11 +1,11 @@
 defmodule Wallaby.Phantom.LoggerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Wallaby.Phantom.Logger
   import ExUnit.CaptureIO
 
-  describe "parse_log/1 INFO logs" do
-    test "removes line numbers from the end of the log" do
+  describe "parse_log/1" do
+    test "removes line numbers from the end of INFO logs" do
       fun = fn ->
         build_log("test (:)")
         |> Logger.parse_log
@@ -26,6 +26,20 @@ defmodule Wallaby.Phantom.LoggerTest do
       end
 
       assert capture_io(fun) == "test (1:3)\n"
+    end
+
+    test "can be disabled" do
+      Application.put_env(:wallaby, :js_logger, nil)
+
+      fun = fn ->
+        "test log"
+        |> build_log()
+        |> Logger.parse_log
+      end
+
+      assert capture_io(fun) == ""
+
+      Application.put_env(:wallaby, :js_logger, :stdio)
     end
   end
 


### PR DESCRIPTION
Users should be able to disable javascript console logs (or redirect logs to a file instead of `:stdio`).

Fixes #115.