### PR TITLE
Move driver and server under the phantom namespace

### DIFF
--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -16,7 +16,7 @@ defmodule Wallaby.Node do
   }
 
   alias __MODULE__
-  alias Wallaby.Driver
+  alias Wallaby.Phantom.Driver
   alias Wallaby.Session
   alias Wallaby.Node.Query
 

--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -46,7 +46,8 @@ defmodule Wallaby.Node.Query do
     * `:text` - Text that should be found inside the element.
   """
 
-  alias Wallaby.{Node, Driver, Session}
+  alias Wallaby.{Node, Session}
+  alias Wallaby.Phantom.Driver
   alias Wallaby.XPath
   alias __MODULE__
 

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -1,4 +1,22 @@
 defmodule Wallaby.Phantom do
+  use Supervisor
+
+  @moduledoc false
+  @pool_name Wallaby.ServerPool
+
+  def start_link(opts\\[]) do
+    Supervisor.start_link(__MODULE__, :ok, opts)
+  end
+
+  def init(:ok) do
+    children = [
+      :poolboy.child_spec(@pool_name, poolboy_config, []),
+      worker(Wallaby.Phantom.LogStore, []),
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+
   def capabilities(opts) do
     default_capabilities
     |> Map.merge(user_agent_capability(opts[:user_agent]))
@@ -18,6 +36,16 @@ defmodule Wallaby.Phantom do
     }
   end
 
+  def start_session(opts) do
+    server = :poolboy.checkout(@pool_name, true, :infinity)
+    Wallaby.Phantom.Driver.create(server, opts)
+  end
+
+  def end_session(%Wallaby.Session{server: server}=session) do
+    :ok = Wallaby.Session.delete(session)
+    :poolboy.checkin(Wallaby.ServerPool, server)
+  end
+
   def user_agent do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
   end
@@ -25,5 +53,20 @@ defmodule Wallaby.Phantom do
   def user_agent_capability(nil), do: %{}
   def user_agent_capability(ua) do
     %{"phantomjs.page.settings.userAgent" => ua}
+  end
+
+  def pool_size do
+    Application.get_env(:wallaby, :pool_size) || default_pool_size
+  end
+
+  defp poolboy_config do
+    [name: {:local, @pool_name},
+     worker_module: Wallaby.Phantom.Server,
+     size: pool_size,
+     max_overflow: 0]
+  end
+
+  defp default_pool_size do
+    :erlang.system_info(:schedulers_online)
   end
 end

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -1,4 +1,4 @@
-defmodule Wallaby.Driver do
+defmodule Wallaby.Phantom.Driver do
   @moduledoc """
   Implements the webdriver protocol for Phantomjs
   """
@@ -7,7 +7,7 @@ defmodule Wallaby.Driver do
   alias Wallaby.Node
   alias Wallaby.Node.Query
   alias Wallaby.Phantom.Logger
-  alias Wallaby.LogStore
+  alias Wallaby.Phantom.LogStore
 
   @type method :: :post | :get | :delete
   @type url :: String.t
@@ -19,7 +19,7 @@ defmodule Wallaby.Driver do
   Creates a new session with the driver.
   """
   def create(server, opts) do
-    base_url = Wallaby.Server.get_base_url(server)
+    base_url = Wallaby.Phantom.Server.get_base_url(server)
     user_agent =
       Wallaby.Phantom.user_agent
       |> Wallaby.Metadata.append(opts[:metadata])

--- a/lib/wallaby/phantom/log_store.ex
+++ b/lib/wallaby/phantom/log_store.ex
@@ -1,4 +1,4 @@
-defmodule Wallaby.LogStore do
+defmodule Wallaby.Phantom.LogStore do
   def start_link do
     Agent.start_link(fn -> Map.new end, name: __MODULE__)
   end

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -1,4 +1,4 @@
-defmodule Wallaby.Server do
+defmodule Wallaby.Phantom.Server do
   use GenServer
 
   def start_link(_args) do

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -44,7 +44,7 @@ defmodule Wallaby.Session do
     screenshots: list
   }
 
-  alias Wallaby.Driver
+  alias Wallaby.Phantom.Driver
   alias Wallaby.Node
 
   defstruct [:id, :url, :session_url, :server, screenshots: []]

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Phantom.ConfigrationTest do
     end
 
     test "updates the phantomjs command" do
-      assert Wallaby.Server.phantomjs_command(1234, '/tmp/dir') =~ ~r/test\/path\/phantomjs/
+      assert Wallaby.Phantom.Server.phantomjs_command(1234, '/tmp/dir') =~ ~r/test\/path\/phantomjs/
     end
   end
 end

--- a/test/wallaby/phantom/driver/configuration_test.exs
+++ b/test/wallaby/phantom/driver/configuration_test.exs
@@ -1,4 +1,4 @@
-defmodule Wallaby.Driver.ConfigurationTest do
+defmodule Wallaby.Phantom.Driver.ConfigurationTest do
   use Wallaby.SessionCase, async: false
 
   test "js errors can be disabled", %{session: session, server: server} do

--- a/test/wallaby/phantom/driver/js_errors_test.exs
+++ b/test/wallaby/phantom/driver/js_errors_test.exs
@@ -1,4 +1,4 @@
-defmodule Wallaby.Driver.JSErrorsTest do
+defmodule Wallaby.Phantom.Driver.JSErrorsTest do
   use Wallaby.SessionCase, async: true
 
   import ExUnit.CaptureIO

--- a/test/wallaby/phantom/log_store_test.exs
+++ b/test/wallaby/phantom/log_store_test.exs
@@ -1,7 +1,7 @@
-defmodule Wallaby.LogStoreTest do
+defmodule Wallaby.Phantom.LogStoreTest do
   use ExUnit.Case, async: true
 
-  alias Wallaby.LogStore
+  alias Wallaby.Phantom.LogStore
 
   @l1 %{"level" => "INFO", "message" => "l1 (:)", "timestamp" => 1470795015152}
   @l2 %{"level" => "INFO", "message" => "l2 (:)", "timestamp" => 1470795015290}

--- a/test/wallaby/phantom/server_test.exs
+++ b/test/wallaby/phantom/server_test.exs
@@ -1,7 +1,7 @@
-defmodule Wallaby.ServerTest do
+defmodule Wallaby.Phantom.ServerTest do
   use ExUnit.Case, async: true
 
-  alias Wallaby.Server
+  alias Wallaby.Phantom.Server
 
   setup do
     {:ok, server} = Server.start_link([])


### PR DESCRIPTION
This change is an important initial refactor for adding support for selenium. This moves the existing server and driver modules underneath `phantom` and updates the supervisor tree to reflect that change.

This PR fixes https://github.com/keathley/wallaby/projects/1#card-707678