### PR TITLE
Allow clicking on buttons with no type

### DIFF
--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -92,9 +92,9 @@ defmodule Wallaby.QueryError do
     Make sure that id on your #{method(locator)} is `id="#{for_text}"`.
     """
   end
-  def error_message(:button_with_no_type, %{locator: locator}) do
+  def error_message(:button_with_bad_type, %{locator: locator}) do
     """
-    The text '#{expression locator}' matched a button but the button has no 'type' attribute.
+    The text '#{expression locator}' matched a button but the button has an invalid 'type' attribute.
 
     You can fix this by including `type="[submit|reset|button|image]"` on the appropriate button.
     """

--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -298,7 +298,7 @@ defmodule Wallaby.Node.Query do
 
     cond do
       Enum.any?(buttons, &(matching_text?(&1, locator))) ->
-        add_error(query, :button_with_no_type)
+        add_error(query, :button_with_bad_type)
       true ->
         query
     end

--- a/lib/wallaby/xpath.ex
+++ b/lib/wallaby/xpath.ex
@@ -18,7 +18,10 @@ defmodule Wallaby.XPath do
   Match any clickable buttons
   """
   def button(query) do
-    ~s{.//*[self::input | self::button][(./@type = 'submit' or ./@type = 'reset' or ./@type = 'button' or ./@type = 'image')][(((./@id = "#{query}" or ./@name = "#{query}" or ./@value = "#{query}" or ./@alt = "#{query}" or ./@title = "#{query}" or contains(normalize-space(string(.)), "#{query}"))))]}
+    types = "./@type = 'submit' or ./@type = 'reset' or ./@type = 'button' or ./@type = 'image'"
+    locator = ~s{(((./@id = "#{query}" or ./@name = "#{query}" or ./@value = "#{query}" or ./@alt = "#{query}" or ./@title = "#{query}" or contains(normalize-space(string(.)), "#{query}"))))}
+
+    ~s{.//input[#{types}][#{locator}] | .//button[(not(./@type) or #{types})][#{locator}]}
   end
 
   @doc """

--- a/test/support/pages/forms.html
+++ b/test/support/pages/forms.html
@@ -32,6 +32,7 @@
 
       <textarea name="text" rows="8" cols="40"></textarea>
 
+      <button id="button-no-type-id" name="button-no-type">button with no type</button>
       <button type="submit" id="button-submit-id" name="button-submit">Submit button</button>
       <button type="button" id="button-button-id" name="button-button" onclick="document.getElementById('name_field').value = '';">Button button</button>
       <button type="reset" id="button-reset-id" name="button-reset">Reset button</button>
@@ -63,7 +64,7 @@
         <input type="file" name="unlabelled-file">
       </div>
       <button type="other">button with bad type</button>
-      <button>button with no type</button>
+      <input name="input-no-type">
     </form>
 
     <form class="wait-form" action="index.html" method="post">

--- a/test/wallaby/dsl/actions/click_button_test.exs
+++ b/test/wallaby/dsl/actions/click_button_test.exs
@@ -9,6 +9,33 @@ defmodule Wallaby.DSL.Actions.ClickButtonTest do
     {:ok, page: page}
   end
 
+  test "clicking button with no type via button text (submits form)", %{page: page} do
+    current_url =
+      page
+      |> click_button("Submit button")
+      |> get_current_url
+
+    assert current_url == "http://localhost:#{URI.parse(current_url).port}/index.html"
+  end
+
+  test "clicking button with no type via name (submits form)", %{page: page} do
+    current_url =
+      page
+      |> click_button("button-no-type")
+      |> get_current_url
+
+    assert current_url == "http://localhost:#{URI.parse(current_url).port}/index.html"
+  end
+
+  test "clicking button with no type via id (submits form)", %{page: page} do
+    current_url =
+      page
+      |> click_button("button-no-type-id")
+      |> get_current_url
+
+    assert current_url == "http://localhost:#{URI.parse(current_url).port}/index.html"
+  end
+
   test "clicking button type[submit] via button text (submits form)", %{page: page} do
     current_url =
       page
@@ -217,17 +244,17 @@ defmodule Wallaby.DSL.Actions.ClickButtonTest do
     assert click_on(page, "Hidden Button")
   end
 
-  test "throws an error if the button is missing the type attribute", %{page: page} do
-    msg = Wallaby.QueryError.error_message(:button_with_no_type, %{locator: {:button, "button with no type"}})
+  test "throws an error if the button does not include a valid type attribute", %{page: page} do
+    msg = Wallaby.QueryError.error_message(:button_with_bad_type, %{locator: {:button, "button with bad type"}})
     assert_raise Wallaby.QueryError, msg, fn ->
-      click_button(page, "button with no type", [])
+      click_button(page, "button with bad type", [])
     end
   end
 
-  test "throws an error if the button does not include a valid type attribute", %{page: page} do
-    msg = Wallaby.QueryError.error_message(:button_with_no_type, %{locator: {:button, "button with bad type"}})
+  test "throws an error if clicking on an input with no type", %{page: page} do
+    msg = Wallaby.QueryError.error_message(:not_found, %{locator: {:button, "input-no-type"}, conditions: [count: 1, visible: true]})
     assert_raise Wallaby.QueryError, msg, fn ->
-      click_button(page, "button with bad type", [])
+      click_button(page, "input-no-type", [])
     end
   end
 


### PR DESCRIPTION
The default value for `type` is `submit`:
https://w3c.github.io/html/sec-forms.html#element-attrdef-button-type