### PR TITLE
Fix parentheses warnings for Elixir 1.4

### DIFF
--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -22,7 +22,7 @@ defmodule Wallaby do
     import Supervisor.Spec, warn: false
 
     children = [
-      supervisor(driver, [[name: Driver.Supervisor]])
+      supervisor(driver(), [[name: Driver.Supervisor]])
     ]
 
     opts = [strategy: :one_for_one, name: Wallaby.Supervisor]
@@ -30,11 +30,11 @@ defmodule Wallaby do
   end
 
   def start_session(opts \\ []) do
-    driver.start_session(opts)
+    driver().start_session(opts)
   end
 
   def end_session(session) do
-    driver.end_session(session)
+    driver().end_session(session)
   end
 
   def screenshot_on_failure? do

--- a/lib/wallaby/node.ex
+++ b/lib/wallaby/node.ex
@@ -233,7 +233,7 @@ defmodule Wallaby.Node do
     rescue
       e in [Wallaby.ExpectationNotMet] ->
         current_time = :erlang.monotonic_time(:milli_seconds)
-        if (current_time - start_time) < max_wait_time do
+        if (current_time - start_time) < max_wait_time() do
           :timer.sleep(25)
           retry(find_fn, start_time)
         else

--- a/lib/wallaby/node/query.ex
+++ b/lib/wallaby/node/query.ex
@@ -395,7 +395,7 @@ defmodule Wallaby.Node.Query do
   end
 
   def max_time_exceeded?(start_time) do
-    :erlang.monotonic_time(:milli_seconds) - start_time < max_wait_time
+    :erlang.monotonic_time(:milli_seconds) - start_time < max_wait_time()
   end
 
   defp max_wait_time do
@@ -414,7 +414,7 @@ defmodule Wallaby.Node.Query do
   defp build_locator({:file_field, query}), do: {:xpath, XPath.file_field(query)}
 
   defp build_conditions(conditions) do
-    default_conditions
+    default_conditions()
     |> Keyword.merge(conditions)
   end
 

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -10,7 +10,7 @@ defmodule Wallaby.Phantom do
 
   def init(:ok) do
     children = [
-      :poolboy.child_spec(@pool_name, poolboy_config, []),
+      :poolboy.child_spec(@pool_name, poolboy_config(), []),
       worker(Wallaby.Phantom.LogStore, []),
     ]
 
@@ -18,7 +18,7 @@ defmodule Wallaby.Phantom do
   end
 
   def capabilities(opts) do
-    default_capabilities
+    default_capabilities()
     |> Map.merge(user_agent_capability(opts[:user_agent]))
   end
 
@@ -56,13 +56,13 @@ defmodule Wallaby.Phantom do
   end
 
   def pool_size do
-    Application.get_env(:wallaby, :pool_size) || default_pool_size
+    Application.get_env(:wallaby, :pool_size) || default_pool_size()
   end
 
   defp poolboy_config do
     [name: {:local, @pool_name},
      worker_module: Wallaby.Phantom.Server,
-     size: pool_size,
+     size: pool_size(),
      max_overflow: 0]
   end
 

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -22,8 +22,8 @@ defmodule Wallaby.Phantom.Server do
   end
 
   def init(_) do
-    port = find_available_port
-    local_storage = tmp_local_storage
+    port = find_available_port()
+    local_storage = tmp_local_storage()
 
     Port.open({:spawn, phantomjs_command(port, local_storage)}, [:binary, :stream, :use_stdio, :exit_status])
 
@@ -31,7 +31,7 @@ defmodule Wallaby.Phantom.Server do
   end
 
   def phantomjs_command(port, local_storage) do
-    "#{script_path} #{phantomjs_path} --webdriver=#{port} --local-storage-path=#{local_storage} #{args}"
+    "#{script_path()} #{phantomjs_path()} --webdriver=#{port} --local-storage-path=#{local_storage} #{args()}"
   end
 
   defp find_available_port do

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -71,7 +71,7 @@ defmodule Wallaby.Session do
     uri = URI.parse(path)
 
     cond do
-      uri.host == nil && String.length(base_url) == 0 ->
+      uri.host == nil && String.length(base_url()) == 0 ->
         raise Wallaby.NoBaseUrl, path
       uri.host ->
         Driver.visit(session, path)
@@ -94,7 +94,7 @@ defmodule Wallaby.Session do
       screenshotable
       |> Driver.take_screenshot
 
-    path = path_for_screenshot
+    path = path_for_screenshot()
     File.write! path, image_data
 
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
@@ -195,7 +195,7 @@ defmodule Wallaby.Session do
   end
 
   defp request_url(path) do
-    base_url <> path
+    base_url() <> path
   end
 
   defp base_url do
@@ -203,8 +203,8 @@ defmodule Wallaby.Session do
   end
 
   defp path_for_screenshot do
-    File.mkdir_p!(screenshot_dir)
-    "#{screenshot_dir}/#{:erlang.system_time}.png"
+    File.mkdir_p!(screenshot_dir())
+    "#{screenshot_dir()}/#{:erlang.system_time}.png"
   end
 
   defp screenshot_dir do

--- a/mix.exs
+++ b/mix.exs
@@ -10,10 +10,10 @@ defmodule Wallaby.Mixfile do
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
+     package: package(),
      description: "Concurrent feature tests for elixir",
-     deps: deps,
-     docs: docs
+     deps: deps(),
+     docs: docs()
    ]
   end
 


### PR DESCRIPTION
Elixir 1.4 gives warnings like the following:

```
warning: variable "driver" does not exist and is being expanded to "driver()",
please use parentheses to remove the ambiguity or change the variable name
  lib/wallaby.ex:25
```