### PR TITLE
Make `Browser.click/2` return the parent element

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -471,6 +471,8 @@ defmodule Wallaby.Browser do
     parent
     |> find(query)
     |> click()
+
+    parent
   end
   def click(element) do
     Driver.click(element)


### PR DESCRIPTION
This addresses issue #134