### PR TITLE
Element modules and deprecation warnings

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -90,8 +90,8 @@ defmodule Wallaby.Browser do
   state. However, if this error does continue to occur it will cause wallaby to
   loop forever (or until the test is killed by exunit).
   """
-  @opaque result :: {:ok, any()} | {:error, any()}
-  @spec retry((() -> result), timeout) :: result()
+  @opaque sync_result :: {:ok, any()} | {:error, any()}
+  @spec retry((() -> sync_result), timeout) :: sync_result()
 
   def retry(f, start_time \\ current_time()) do
     case f.() do
@@ -117,6 +117,12 @@ defmodule Wallaby.Browser do
   @spec fill_in(parent, locator, opts) :: parent
 
   def fill_in(parent, locator, [{:with, value} | _]=opts) when is_binary(locator) do
+    IO.warn """
+    fill_in/3 with string locators has been deprecated. Please use a query:
+    
+    fill_in(parent, Query.text_field("#{locator}"), with: "#{value}")
+    """
+
     parent
     |> find(Query.fillable_field(locator, opts), & fill_in(&1, with: value))
   end
@@ -128,6 +134,8 @@ defmodule Wallaby.Browser do
     fill_in(element, with: to_string(value))
   end
   def fill_in(%Element{}=element, with: value) when is_binary(value) do
+    IO.warn "fill_in/2 has been deprecated. Please use Element.fill_in/2"
+
     element
     |> clear
     |> set_value(value)
@@ -141,18 +149,34 @@ defmodule Wallaby.Browser do
   @spec choose(parent, locator, opts) :: parent
 
   def choose(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    choose/3 has been deprecated. Please use:
+    
+    click(parent, Query.radio_button("#{locator}", #{opts}))
+    """
+
     parent
     |> find(Query.radio_button(locator, opts), &(click(&1)))
   end
   def choose(parent, locator) when is_binary(locator) do
+    IO.warn """
+    choose/2 has been deprecated. Please use:
+    
+    click(parent, Query.radio_button("#{locator}"))
+    """
+
     parent
     |> find(Query.radio_button(locator, []), &(click(&1)))
   end
   def choose(parent, query) do
+    IO.warn "choose/2 has been deprecated. Please use click/2"
+
     parent
     |> find(query, &(click(&1)))
   end
   def choose(%Element{}=element) do
+    IO.warn "choose/1 has been deprecated. Please use Element.click/1"
+
     click(element)
   end
 
@@ -164,20 +188,36 @@ defmodule Wallaby.Browser do
   @spec check(parent, locator, opts) :: parent
 
   def check(%Element{}=element) do
+    IO.warn "check/1 has been deprecated. Please use Element.check/1"
+
     cond do
       checked?(element) -> element
       true -> click(element)
     end
   end
   def check(parent, locator) when is_binary(locator) do
+    IO.warn """
+    check/2 has been deprecated. Please use:
+    
+    click(parent, Query.checkbox("#{locator}"))
+    """
+
     parent
     |> find(Query.checkbox(locator, []), &(check(&1)))
   end
   def check(parent, query) do
+    IO.warn "check/2 has been deprecated. Please use click/2"
+
     parent
     |> find(query, &(check(&1)))
   end
   def check(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    check/2 has been deprecated. Please use:
+    
+    click(parent, Query.checkbox("#{locator}", #{opts}))
+    """
+
     parent
     |> find(Query.checkbox(locator, opts), &(check(&1)))
   end
@@ -190,18 +230,34 @@ defmodule Wallaby.Browser do
   @spec uncheck(parent, locator, opts) :: parent
 
   def uncheck(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    uncheck/2 has been deprecated. Please use:
+    
+    click(parent, Query.checkbox("#{locator}", #{opts}))
+    """
+
     parent
     |> find(Query.checkbox(locator, opts), &(uncheck(&1)))
   end
   def uncheck(parent, locator) when is_binary(locator) do
+    IO.warn """
+    check/2 has been deprecated. Please use:
+    
+    click(parent, Query.checkbox("#{locator}"))
+    """
+
     parent
     |> find(Query.checkbox(locator, []), &(uncheck(&1)))
   end
   def uncheck(parent, query) do
+    IO.warn "uncheck/2 has been deprecated. Please use click/2"
+
     parent
     |> find(query, &(uncheck(&1)))
   end
   def uncheck(%Element{}=element) do
+    IO.warn "uncheck/1 has been deprecated. Please use Element.click/1"
+
     if checked?(element) do
       click(element)
     end
@@ -218,14 +274,24 @@ defmodule Wallaby.Browser do
   @spec select(parent, locator, opts) :: parent
 
   def select(element) do
+    IO.warn "select/1 has been deprecated. Please use Element.click/1"
+
     element
     |> click
   end
   def select(parent, query) do
+    IO.warn "select/2 has been deprecated. Please use click/2"
+
     parent
     |> find(query, &(click(&1)))
   end
   def select(parent, locator, [option: option_text]=opts) do
+    IO.warn """
+    select/3 has been deprecated. Please use:
+
+    click(parent, Query.option("#{option_text}"))
+    """
+
     find(parent, Query.select(locator, opts), fn(select_field) ->
       find(select_field, Query.option(option_text, []), fn(option) ->
         click(option)
@@ -240,14 +306,28 @@ defmodule Wallaby.Browser do
   @spec click_link(parent, locator, opts) :: parent
 
   def click_link(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    click_link/3 has been deprecated. Please use:
+
+    click(parent, Query.link("#{locator}", #{opts}))
+    """
+
     parent
     |> click(Query.link(locator, opts))
   end
   def click_link(parent, locator) when is_binary(locator) do
+    IO.warn """
+    click_link/2 has been deprecated. Please use:
+
+    click(parent, Query.link("#{locator}"))
+    """
+
     parent
     |> click(Query.link(locator, []))
   end
   def click_link(parent, query) do
+    IO.warn "click_link/2 has been deprecated. Please use click/2"
+
     click(parent, query)
   end
 
@@ -258,14 +338,28 @@ defmodule Wallaby.Browser do
   @spec click_button(parent, locator, opts) :: parent
 
   def click_button(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    click_button/3 has been deprecated. Please use:
+
+    click(parent, Query.button("#{locator}", #{opts}))
+    """
+
     parent
     |> click(Query.button(locator, opts))
   end
   def click_button(parent, locator) when is_binary(locator) do
+    IO.warn """
+    click_button/2 has been deprecated. Please use:
+
+    click(parent, Query.button("#{locator}"))
+    """
+
     parent
     |> click(Query.button(locator, []))
   end
   def click_button(parent, query) do
+    IO.warn "click_button/2 has been deprecated. Please use click/2"
+
     click(parent, query)
   end
 
@@ -278,6 +372,12 @@ defmodule Wallaby.Browser do
   @spec clear(Element.t) :: Element.t
 
   def clear(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    clear/3 has been deprecated. Please use:
+
+    clear(parent, Query.css("#{locator}", #{opts}))
+    """
+
     clear(parent, Query.fillable_field(locator, opts))
   end
   def clear(parent, query) do
@@ -285,6 +385,8 @@ defmodule Wallaby.Browser do
     |> find(query, &clear/1)
   end
   def clear(element) do
+    IO.warn "clear/1 has been deprecated. Please use Element.clear/1"
+
     {:ok, _} = Driver.clear(element)
     element
   end
@@ -297,6 +399,12 @@ defmodule Wallaby.Browser do
   @spec attach_file(parent, queryable, path: String.t) :: parent
 
   def attach_file(parent, locator, [{:path, value} | _]=opts) when is_binary(locator) do
+    IO.warn """
+    attach_file/3 with string locators has been deprecated. Please use:
+
+    attach_file(parent, Query.file_field("#{locator}"))
+    """
+
     parent
     |> fill_in(Query.file_field(locator, opts), with: :filename.absname(value))
   end
@@ -343,7 +451,11 @@ defmodule Wallaby.Browser do
     session
   end
 
-  defdelegate set_window_size(parent, x, y), to: Wallaby.Browser, as: :resize_window
+  def set_window_size(parent, x, y) do
+    IO.warn "set_window_size/3 has been deprecated. Please use resize_window/3"
+
+    resize_window(parent, x, y)
+  end
 
   @doc """
   Gets the current url of the session
@@ -354,7 +466,11 @@ defmodule Wallaby.Browser do
     Driver.current_url!(parent)
   end
 
-  defdelegate get_current_url(parent), to: __MODULE__, as: :current_url
+  def get_current_url(parent) do
+    IO.warn "get_current_url/1 has been deprecated. Please use current_url/1"
+
+    current_url(parent)
+  end
 
   @doc """
   Gets the current path of the session
@@ -418,7 +534,11 @@ defmodule Wallaby.Browser do
     parent
   end
 
-  defdelegate send_text(parent, keys), to: __MODULE__, as: :send_keys
+  def send_text(parent, keys) do
+    IO.warn "send_text/2 has been deprecated. Please use send_keys/2"
+
+    send_keys(parent, keys)
+  end
 
   @doc """
   Retrieves the source of the current page.
@@ -447,6 +567,12 @@ defmodule Wallaby.Browser do
   @spec click(Element.t) :: Element.t
 
   def click(parent, locator) when is_binary(locator) do
+    IO.warn """
+    click/2 with string locator has been deprecated. Please use:
+    
+    click(parent, Query.button("#{locator}"))
+    """
+
     parent
     |> find(Query.button(locator), &click/1)
   end
@@ -455,12 +581,20 @@ defmodule Wallaby.Browser do
     |> find(query, &click/1)
   end
   def click(element) do
+    IO.warn "click/1 has been deprecated. Please use Element.click/1"
+
     Driver.click(element)
 
     element
   end
 
-  defdelegate click_on(parent, query), to: __MODULE__, as: :click
+  def click_on(parent, query) do
+    IO.warn """
+    click_on/2 has been deprecated. Please use Browser.click/2.
+    """
+
+    click(parent, query)
+  end
 
   @doc """
   Gets the Element's text value.
@@ -479,6 +613,8 @@ defmodule Wallaby.Browser do
     |> text()
   end
   def text(%Element{}=element) do
+    IO.warn "text/1 has been deprecated. Please use Element.text/1"
+
     case Driver.text(element) do
       {:ok, text} ->
         text
@@ -494,6 +630,8 @@ defmodule Wallaby.Browser do
   @spec attr(Element.t, String.t) :: String.t | nil
 
   def attr(element, name) do
+    IO.warn "attr/2 has been deprecated. Please use Element.attr/2"
+
     {:ok, attribute} = Driver.attribute(element, name)
     attribute
   end
@@ -510,9 +648,11 @@ defmodule Wallaby.Browser do
   @spec checked?(Element.t) :: boolean()
 
   def checked?(parent, query) do
+    IO.warn "checked?/2 has been deprecated. Please use selected?/2"
     selected?(parent, query)
   end
   def checked?(%Element{}=element) do
+    IO.warn "checked?/1 has been deprecated. Please use Element.selected?/1"
     selected?(element)
   end
 
@@ -528,6 +668,8 @@ defmodule Wallaby.Browser do
     |> selected?
   end
   def selected?(%Element{}=element) do
+    IO.warn "selected?/1 has been deprecated. Please use Element.selected?/1"
+
     case Driver.selected(element) do
       {:ok, value} ->
         value
@@ -543,6 +685,8 @@ defmodule Wallaby.Browser do
   @spec visible?(Element.t) :: boolean()
 
   def visible?(%Element{}=element) do
+    IO.warn "visible?/1 has been deprecated. Please use Element.visible?/1"
+
     Driver.displayed!(element)
   end
   def visible?(parent, query) do
@@ -567,6 +711,12 @@ defmodule Wallaby.Browser do
   @spec find(parent, locator) :: Element.t | [Element.t]
 
   def find(parent, css, opts) when is_binary(css) and is_list(opts) do
+    IO.warn """
+    find/3 with string locators has beeen deprecated. Please use:
+
+    find(parent, Query.css("#{css}", #{opts}))
+    """
+
     find(parent, Query.css(css, opts))
   end
   def find(parent, %Query{}=query, callback) when is_function(callback) do
@@ -575,9 +725,21 @@ defmodule Wallaby.Browser do
     parent
   end
   def find(parent, {:xpath, path}) when is_binary(path) do
+    IO.warn """
+    find/3 with {:xpath, locator} has beeen deprecated. Please use:
+
+    find(parent, Query.xpath("#{path}"))
+    """
+
     find(parent, Query.xpath(path))
   end
   def find(parent, css) when is_binary(css) do
+    IO.warn """
+    find/3 with string locators has beeen deprecated. Please use:
+
+    find(parent, Query.css("#{css}"))
+    """
+
     find(parent, Query.css(css))
   end
   def find(parent, %Query{}=query) do
@@ -618,9 +780,21 @@ defmodule Wallaby.Browser do
   @spec all(parent, Query.t) :: [Element.t]
 
   def all(parent, locator, opts) when is_binary(locator) do
+    IO.warn """
+    all/3 with string locators has been deprecated. Please use:
+
+    all(parent, Query.css("#{locator}", #{opts}))
+    """
+
     find(parent, Query.css(locator, Keyword.merge(opts, [count: nil, minimum: 0])))
   end
   def all(parent, css) when is_binary(css) do
+    IO.warn """
+    all/2 with string locators has been deprecated. Please use:
+
+    all(parent, Query.css("#{css}"))
+    """
+
     find(parent, Query.css(css, minimum: 0))
   end
   def all(parent, %Query{}=query) do
@@ -727,7 +901,6 @@ defmodule Wallaby.Browser do
   @spec has_no_css?(parent, Query.t, String.t) :: boolean()
   @spec has_no_css?(parent, locator) :: boolean()
 
-  # TODO: Untested
   def has_no_css?(parent, query, css) when is_binary(css) do
     parent
     |> find(query)

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -122,11 +122,11 @@ defmodule Wallaby.Browser do
     """
 
     parent
-    |> find(Query.fillable_field(locator, opts), &(fill_in(&1, with: value)))
+    |> find(Query.fillable_field(locator, opts), &(Element.fill_in(&1, with: value)))
   end
   def fill_in(parent, query, with: value) do
     parent
-    |> find(query, &(fill_in(&1, with: value)))
+    |> find(query, &(Element.fill_in(&1, with: value)))
   end
   def fill_in(%Element{}=element, with: value) do
     IO.warn "fill_in/2 has been deprecated. Please use Element.fill_in/2"
@@ -180,7 +180,7 @@ defmodule Wallaby.Browser do
     IO.warn "check/1 has been deprecated. Please use Element.click/1"
 
     cond do
-      checked?(element) -> element
+      Element.selected?(element) -> element
       true -> Element.click(element)
     end
   end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -130,15 +130,10 @@ defmodule Wallaby.Browser do
     parent
     |> find(query, &(fill_in(&1, with: value)))
   end
-  def fill_in(%Element{}=element, with: value) when is_number(value) do
-    fill_in(element, with: to_string(value))
-  end
-  def fill_in(%Element{}=element, with: value) when is_binary(value) do
+  def fill_in(%Element{}=element, with: value) do
     IO.warn "fill_in/2 has been deprecated. Please use Element.fill_in/2"
 
-    element
-    |> clear
-    |> set_value(value)
+    Element.fill_in(element, with: value)
   end
 
   @doc """
@@ -386,9 +381,7 @@ defmodule Wallaby.Browser do
   end
   def clear(element) do
     IO.warn "clear/1 has been deprecated. Please use Element.clear/1"
-
-    {:ok, _} = Driver.clear(element)
-    element
+    Element.clear(element)
   end
 
   @doc """
@@ -556,8 +549,9 @@ defmodule Wallaby.Browser do
   @spec set_value(element, any()) :: element
 
   def set_value(element, value) do
-    {:ok, _} = Driver.set_value(element, value)
-    element
+    IO.warn "set_value/2 has been deprecated. Please use Element.set_value/2"
+
+    Element.set_value(element, value)
   end
 
   @doc """
@@ -583,9 +577,7 @@ defmodule Wallaby.Browser do
   def click(element) do
     IO.warn "click/1 has been deprecated. Please use Element.click/1"
 
-    Driver.click(element)
-
-    element
+    Element.click(element)
   end
 
   def click_on(parent, query) do
@@ -615,12 +607,7 @@ defmodule Wallaby.Browser do
   def text(%Element{}=element) do
     IO.warn "text/1 has been deprecated. Please use Element.text/1"
 
-    case Driver.text(element) do
-      {:ok, text} ->
-        text
-      {:error, :stale_reference_error} ->
-        raise Wallaby.StaleReferenceException
-    end
+    Element.text(element)
   end
 
   @doc """
@@ -631,14 +618,12 @@ defmodule Wallaby.Browser do
 
   def attr(element, name) do
     IO.warn "attr/2 has been deprecated. Please use Element.attr/2"
-
-    {:ok, attribute} = Driver.attribute(element, name)
-    attribute
+    Element.attr(element, name)
   end
   def attr(parent, query, name) do
     parent
     |> find(query)
-    |> attr(name)
+    |> Element.attr(name)
   end
 
   @doc """
@@ -653,7 +638,7 @@ defmodule Wallaby.Browser do
   end
   def checked?(%Element{}=element) do
     IO.warn "checked?/1 has been deprecated. Please use Element.selected?/1"
-    selected?(element)
+    Element.selected?(element)
   end
 
   @doc """
@@ -670,12 +655,7 @@ defmodule Wallaby.Browser do
   def selected?(%Element{}=element) do
     IO.warn "selected?/1 has been deprecated. Please use Element.selected?/1"
 
-    case Driver.selected(element) do
-      {:ok, value} ->
-        value
-      {:error, _} ->
-        false
-    end
+    Element.selected?(element)
   end
 
   @doc """
@@ -687,7 +667,7 @@ defmodule Wallaby.Browser do
   def visible?(%Element{}=element) do
     IO.warn "visible?/1 has been deprecated. Please use Element.visible?/1"
 
-    Driver.displayed!(element)
+    Element.visible?(element)
   end
   def visible?(parent, query) do
     parent

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -118,13 +118,11 @@ defmodule Wallaby.Browser do
 
   def fill_in(parent, locator, [{:with, value} | _]=opts) when is_binary(locator) do
     IO.warn """
-    fill_in/3 with string locators has been deprecated. Please use a query:
-    
-    fill_in(parent, Query.text_field("#{locator}"), with: "#{value}")
+    fill_in/3 with string locators has been deprecated. Please use a query: fill_in(parent, Query.text_field("#{locator}"), with: "#{value}")
     """
 
     parent
-    |> find(Query.fillable_field(locator, opts), & fill_in(&1, with: value))
+    |> find(Query.fillable_field(locator, opts), &(fill_in(&1, with: value)))
   end
   def fill_in(parent, query, with: value) do
     parent
@@ -145,34 +143,30 @@ defmodule Wallaby.Browser do
 
   def choose(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    choose/3 has been deprecated. Please use:
-    
-    click(parent, Query.radio_button("#{locator}", #{opts}))
+    choose/3 has been deprecated. Please use: click(parent, Query.radio_button("#{locator}", #{opts}))
     """
 
     parent
-    |> find(Query.radio_button(locator, opts), &(click(&1)))
+    |> find(Query.radio_button(locator, opts), &Element.click/1)
   end
   def choose(parent, locator) when is_binary(locator) do
     IO.warn """
-    choose/2 has been deprecated. Please use:
-    
-    click(parent, Query.radio_button("#{locator}"))
+    choose/2 has been deprecated. Please use: click(parent, Query.radio_button("#{locator}"))
     """
 
     parent
-    |> find(Query.radio_button(locator, []), &(click(&1)))
+    |> find(Query.radio_button(locator, []), &Element.click/1)
   end
   def choose(parent, query) do
     IO.warn "choose/2 has been deprecated. Please use click/2"
 
     parent
-    |> find(query, &(click(&1)))
+    |> find(query, &Element.click/1)
   end
   def choose(%Element{}=element) do
     IO.warn "choose/1 has been deprecated. Please use Element.click/1"
 
-    click(element)
+    Element.click(element)
   end
 
   @doc """
@@ -183,38 +177,46 @@ defmodule Wallaby.Browser do
   @spec check(parent, locator, opts) :: parent
 
   def check(%Element{}=element) do
-    IO.warn "check/1 has been deprecated. Please use Element.check/1"
+    IO.warn "check/1 has been deprecated. Please use Element.click/1"
 
     cond do
       checked?(element) -> element
-      true -> click(element)
+      true -> Element.click(element)
     end
   end
   def check(parent, locator) when is_binary(locator) do
     IO.warn """
-    check/2 has been deprecated. Please use:
-    
-    click(parent, Query.checkbox("#{locator}"))
+    check/2 has been deprecated. Please use: click(parent, Query.checkbox("#{locator}"))
     """
 
     parent
-    |> find(Query.checkbox(locator, []), &(check(&1)))
+    |> find(Query.checkbox(locator, []), fn(element) ->
+      if !Element.selected?(element) do
+	Element.click(element)
+      end
+    end)
   end
   def check(parent, query) do
     IO.warn "check/2 has been deprecated. Please use click/2"
 
     parent
-    |> find(query, &(check(&1)))
+    |> find(query, fn (element) ->
+      if !Element.selected?(element) do
+	Element.click(element)
+      end
+    end)
   end
   def check(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    check/2 has been deprecated. Please use:
-    
-    click(parent, Query.checkbox("#{locator}", #{opts}))
+    check/2 has been deprecated. Please use: click(parent, Query.checkbox("#{locator}", #{opts}))
     """
 
     parent
-    |> find(Query.checkbox(locator, opts), &(check(&1)))
+    |> find(Query.checkbox(locator, opts), fn(element) ->
+      if ! Element.selected?(element) do
+	Element.click(element)
+      end
+    end)
   end
 
   @doc """
@@ -226,35 +228,38 @@ defmodule Wallaby.Browser do
 
   def uncheck(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    uncheck/2 has been deprecated. Please use:
-    
-    click(parent, Query.checkbox("#{locator}", #{opts}))
+    uncheck/2 has been deprecated. Please use: click(parent, Query.checkbox("#{locator}", #{opts}))
     """
 
     parent
-    |> find(Query.checkbox(locator, opts), &(uncheck(&1)))
+    |> find(Query.checkbox(locator, opts), &Element.click/1)
   end
   def uncheck(parent, locator) when is_binary(locator) do
     IO.warn """
-    check/2 has been deprecated. Please use:
-    
-    click(parent, Query.checkbox("#{locator}"))
+    check/2 has been deprecated. Please use: click(parent, Query.checkbox("#{locator}"))
     """
-
     parent
-    |> find(Query.checkbox(locator, []), &(uncheck(&1)))
+    |> find(Query.checkbox(locator, []), fn (element) ->
+      if Element.selected?(element) do
+	Element.click(element)
+      end
+    end)
   end
   def uncheck(parent, query) do
     IO.warn "uncheck/2 has been deprecated. Please use click/2"
 
     parent
-    |> find(query, &(uncheck(&1)))
+    |> find(query, fn(element) ->
+      if Element.selected?(element) do
+	Element.click(element)
+      end
+    end)
   end
   def uncheck(%Element{}=element) do
     IO.warn "uncheck/1 has been deprecated. Please use Element.click/1"
 
-    if checked?(element) do
-      click(element)
+    if Element.selected?(element) do
+      Element.click(element)
     end
     element
   end
@@ -271,14 +276,13 @@ defmodule Wallaby.Browser do
   def select(element) do
     IO.warn "select/1 has been deprecated. Please use Element.click/1"
 
-    element
-    |> click
+    Element.click(element)
   end
   def select(parent, query) do
     IO.warn "select/2 has been deprecated. Please use click/2"
 
     parent
-    |> find(query, &(click(&1)))
+    |> find(query, &Element.click/1)
   end
   def select(parent, locator, [option: option_text]=opts) do
     IO.warn """
@@ -289,7 +293,7 @@ defmodule Wallaby.Browser do
 
     find(parent, Query.select(locator, opts), fn(select_field) ->
       find(select_field, Query.option(option_text, []), fn(option) ->
-        click(option)
+        Element.click(option)
       end)
     end)
   end
@@ -302,9 +306,7 @@ defmodule Wallaby.Browser do
 
   def click_link(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    click_link/3 has been deprecated. Please use:
-
-    click(parent, Query.link("#{locator}", #{opts}))
+    click_link/3 has been deprecated. Please use: click(parent, Query.link("#{locator}", #{opts}))
     """
 
     parent
@@ -312,9 +314,7 @@ defmodule Wallaby.Browser do
   end
   def click_link(parent, locator) when is_binary(locator) do
     IO.warn """
-    click_link/2 has been deprecated. Please use:
-
-    click(parent, Query.link("#{locator}"))
+    click_link/2 has been deprecated. Please use: click(parent, Query.link("#{locator}"))
     """
 
     parent
@@ -334,9 +334,7 @@ defmodule Wallaby.Browser do
 
   def click_button(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    click_button/3 has been deprecated. Please use:
-
-    click(parent, Query.button("#{locator}", #{opts}))
+    click_button/3 has been deprecated. Please use: click(parent, Query.button("#{locator}", #{opts}))
     """
 
     parent
@@ -344,9 +342,7 @@ defmodule Wallaby.Browser do
   end
   def click_button(parent, locator) when is_binary(locator) do
     IO.warn """
-    click_button/2 has been deprecated. Please use:
-
-    click(parent, Query.button("#{locator}"))
+    click_button/2 has been deprecated. Please use: click(parent, Query.button("#{locator}"))
     """
 
     parent
@@ -368,19 +364,18 @@ defmodule Wallaby.Browser do
 
   def clear(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    clear/3 has been deprecated. Please use:
-
-    clear(parent, Query.css("#{locator}", #{opts}))
+    clear/3 has been deprecated. Please use: clear(parent, Query.css("#{locator}", #{opts}))
     """
 
     clear(parent, Query.fillable_field(locator, opts))
   end
   def clear(parent, query) do
     parent
-    |> find(query, &clear/1)
+    |> find(query, &Element.clear/1)
   end
   def clear(element) do
     IO.warn "clear/1 has been deprecated. Please use Element.clear/1"
+
     Element.clear(element)
   end
 
@@ -568,11 +563,11 @@ defmodule Wallaby.Browser do
     """
 
     parent
-    |> find(Query.button(locator), &click/1)
+    |> find(Query.button(locator), &Element.click/1)
   end
   def click(parent, query) do
     parent
-    |> find(query, &click/1)
+    |> find(query, &Element.click/1)
   end
   def click(element) do
     IO.warn "click/1 has been deprecated. Please use Element.click/1"
@@ -597,12 +592,12 @@ defmodule Wallaby.Browser do
   def text(parent, query) do
     parent
     |> find(query)
-    |> text
+    |> Element.text
   end
   def text(%Session{}=session) do
     session
     |> find(Query.css("body"))
-    |> text()
+    |> Element.text()
   end
   def text(%Element{}=element) do
     IO.warn "text/1 has been deprecated. Please use Element.text/1"
@@ -650,7 +645,7 @@ defmodule Wallaby.Browser do
   def selected?(parent, query) do
     parent
     |> find(query)
-    |> selected?
+    |> Element.selected?
   end
   def selected?(%Element{}=element) do
     IO.warn "selected?/1 has been deprecated. Please use Element.selected?/1"
@@ -692,9 +687,7 @@ defmodule Wallaby.Browser do
 
   def find(parent, css, opts) when is_binary(css) and is_list(opts) do
     IO.warn """
-    find/3 with string locators has beeen deprecated. Please use:
-
-    find(parent, Query.css("#{css}", #{opts}))
+    find/3 with string locators has beeen deprecated. Please use: find(parent, Query.css("#{css}", #{opts}))
     """
 
     find(parent, Query.css(css, opts))
@@ -706,18 +699,14 @@ defmodule Wallaby.Browser do
   end
   def find(parent, {:xpath, path}) when is_binary(path) do
     IO.warn """
-    find/3 with {:xpath, locator} has beeen deprecated. Please use:
-
-    find(parent, Query.xpath("#{path}"))
+    find/3 with {:xpath, locator} has beeen deprecated. Please use: find(parent, Query.xpath("#{path}"))
     """
 
     find(parent, Query.xpath(path))
   end
   def find(parent, css) when is_binary(css) do
     IO.warn """
-    find/3 with string locators has beeen deprecated. Please use:
-
-    find(parent, Query.css("#{css}"))
+    find/3 with string locators has beeen deprecated. Please use: find(parent, Query.css("#{css}"))
     """
 
     find(parent, Query.css(css))
@@ -761,18 +750,14 @@ defmodule Wallaby.Browser do
 
   def all(parent, locator, opts) when is_binary(locator) do
     IO.warn """
-    all/3 with string locators has been deprecated. Please use:
-
-    all(parent, Query.css("#{locator}", #{opts}))
+    all/3 with string locators has been deprecated. Please use: all(parent, Query.css("#{locator}", #{opts}))
     """
 
     find(parent, Query.css(locator, Keyword.merge(opts, [count: nil, minimum: 0])))
   end
   def all(parent, css) when is_binary(css) do
     IO.warn """
-    all/2 with string locators has been deprecated. Please use:
-
-    all(parent, Query.css("#{css}"))
+    all/2 with string locators has been deprecated. Please use: all(parent, Query.css("#{css}"))
     """
 
     find(parent, Query.css(css, minimum: 0))
@@ -808,7 +793,7 @@ defmodule Wallaby.Browser do
     |> has_value?(value)
   end
   def has_value?(%Element{}=element, value) do
-    attr(element, "value") == value
+    Element.attr(element, "value") == value
   end
 
   @doc """
@@ -822,10 +807,15 @@ defmodule Wallaby.Browser do
     |> find(query)
     |> has_text?(text)
   end
+  def has_text?(%Session{}=session, text) when is_binary(text) do
+    session
+    |> find(Query.css("body"))
+    |> has_text?(text)
+  end
   def has_text?(parent, text) when is_binary(text) do
     result = retry fn ->
       cond do
-        text(parent) =~ text ->
+        Element.text(parent) =~ text ->
           {:ok, true}
         true ->
           {:error, false}
@@ -931,7 +921,7 @@ defmodule Wallaby.Browser do
       Enum.any?(labels, &(missing_for?(&1))) ->
         {:error, :label_with_no_for}
       label=List.first(labels) ->
-        {:error, {:label_does_not_find_field, attr(label, "for")}}
+        {:error, {:label_does_not_find_field, Element.attr(label, "for")}}
       true ->
         {:ok, query}
     end
@@ -939,13 +929,13 @@ defmodule Wallaby.Browser do
   defp validate_html(_, query), do: {:ok, query}
 
   defp missing_for?(element) do
-    attr(element, "for") == nil
+    Element.attr(element, "for") == nil
   end
 
   defp validate_visibility(query, elements) do
     visible = Query.visible?(query)
 
-    {:ok, Enum.filter(elements, &(visible?(&1) == visible))}
+    {:ok, Enum.filter(elements, &(Element.visible?(&1) == visible))}
   end
 
   defp validate_count(query, elements) do

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -841,9 +841,9 @@ defmodule Wallaby.Browser do
     |> find(query)
     |> assert_text(text)
   end
-  def assert_text(%Element{}=element, text) when is_binary(text) do
+  def assert_text(parent, text) when is_binary(text) do
     cond do
-      has_text?(element, text) -> true
+      has_text?(parent, text) -> true
       true -> raise Wallaby.ExpectationNotMet, "Text '#{text}' was not found."
     end
   end

--- a/lib/wallaby/dsl.ex
+++ b/lib/wallaby/dsl.ex
@@ -4,6 +4,8 @@ defmodule Wallaby.DSL do
   defmacro __using__([]) do
     quote do
       alias Wallaby.Query
+      alias Wallaby.Browser
+      alias Wallaby.Element
       import Wallaby.Browser
     end
   end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -3,6 +3,8 @@ defmodule Wallaby.Element do
   Defines an Element Struct
   """
 
+  alias Wallaby.Phantom.Driver
+
   defstruct [:url, :session_url, :parent, :id, screenshots: []]
 
   @type url :: String.t
@@ -14,4 +16,77 @@ defmodule Wallaby.Element do
     id: String.t,
     screenshots: list,
   }
+
+  def clear(element) do
+    case Driver.clear(element) do
+      {:ok, _} ->
+	element
+      {:error, _} ->
+	raise Wallaby.StaleReferenceException
+    end
+  end
+
+  def fill_in(element, with: value) when is_number(value) do
+    fill_in(element, with: to_string(value))
+  end
+  def fill_in(element, with: value) when is_binary(value) do
+    element
+    |> clear
+    |> set_value(value)
+  end
+
+  def click(element) do
+    case Driver.click(element) do
+      {:ok, _} ->
+	element
+      {:error, _} ->
+	raise Wallaby.StaleReferenceException
+    end
+  end
+
+  def text(element) do
+    case Driver.text(element) do
+      {:ok, text} ->
+        text
+      {:error, :stale_reference_error} ->
+        raise Wallaby.StaleReferenceException
+    end
+  end
+
+  def attr(element, name) do
+    case Driver.attribute(element, name) do
+      {:ok, attribute} ->
+	attribute
+      {:error, _} ->
+	raise Wallaby.StaleReferenceException
+    end
+  end
+
+  def selected?(element) do
+    case Driver.selected(element) do
+      {:ok, value} ->
+        value
+      {:error, _} ->
+        false
+    end
+  end
+
+  def visible?(element) do
+    case Driver.displayed(element) do
+      {:ok, value} ->
+	value
+      {:error, _} ->
+	false
+    end
+  end
+
+  def set_value(element, value) do
+    case Driver.set_value(element, value) do
+      {:ok, _} ->
+	element
+      {:error, :stale_reference_error} ->
+	raise Wallaby.StaleReferenceException
+    end
+  end
 end
+

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -50,5 +50,9 @@ defmodule Wallaby.Session do
 
   defstruct [:id, :url, :session_url, :server, screenshots: []]
 
-  defdelegate set_window_size(parent, x, y), to: Wallaby.Browser
+  def set_window_size(parent, x, y) do
+    IO.warn "set_window_size/3 has been deprecated. Please use Browser.resize_window/3"
+
+    Wallaby.Browser.resize_window(parent, x, y)
+  end
 end

--- a/test/wallaby/browser/assert_text_test.exs
+++ b/test/wallaby/browser/assert_text_test.exs
@@ -30,4 +30,11 @@ defmodule Wallaby.Browser.AssertTextTest do
       assert_text(element, "rain")
     end
   end
+
+  test "assert_text/2 works with sessions", %{session: session} do
+    session
+    |> Browser.visit("wait.html")
+
+    assert Browser.assert_text(session, "main")
+  end
 end

--- a/test/wallaby/browser/has_text_test.exs
+++ b/test/wallaby/browser/has_text_test.exs
@@ -33,7 +33,6 @@ defmodule Wallaby.Browser.HasTextTest do
       |> has_text?("Page 1")
     end
 
-    @tag :focus
     test "retries the query", %{page: page} do
       assert page
       |> visit("wait.html")


### PR DESCRIPTION
I have moved the functionality specific to elements to the `Element` module. I've also added deprecation warnings for the pieces of the api that are going to be removed after the 0.16 release.