### PR TITLE
Send keys works with both sessions and elements.

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -550,29 +550,34 @@ defmodule Wallaby.Browser do
       iex> Wallaby.Session.send_keys(session, [:enter])
       iex> Wallaby.Session.send_keys(session, [:shift, :enter])
   """
-  @spec send_keys(parent, list(atom)) :: parent
-  @spec send_keys(parent, Query.t, list(atom)) :: parent
+  @spec send_keys(parent, Query.t, list(atom) | String.t) :: parent
+  @spec send_keys(parent, list(atom) | String.t) :: parent
 
   def send_keys(parent, query, list) do
     find(parent, query, fn(element) ->
       element
-      |> click()
-      |> send_keys(list)
+      |> Element.send_keys(list)
     end)
   end
-  def send_keys(parent, text) when is_binary(text) do
-    send_keys(parent, [text])
+  def send_keys(%Element{}=element, keys) do
+    Element.send_keys(element, keys)
   end
+
   def send_keys(parent, keys) when is_list(keys) do
     {:ok, _} = Driver.send_keys(parent, keys)
     parent
   end
 
+  def send_text(parent, query, keys) do
+    IO.warn "send_text/3 has been deprecated. Please use send_keys/3"
+    send_keys(parent, query, keys)
+  end
+
   def send_text(parent, keys) do
     IO.warn "send_text/2 has been deprecated. Please use send_keys/2"
-
     send_keys(parent, keys)
   end
+
 
   @doc """
   Retrieves the source of the current page.
@@ -839,7 +844,7 @@ defmodule Wallaby.Browser do
     |> has_value?(value)
   end
   def has_value?(%Element{}=element, value) do
-    Element.attr(element, "value") == value
+    Element.value(element) == value
   end
 
   @doc """

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -155,4 +155,30 @@ defmodule Wallaby.Element do
 	raise Wallaby.StaleReferenceException
     end
   end
+
+  @doc """
+  Sends keys to the element.
+  """
+  @spec send_keys(Element.t, String.t | list(atom | String.t)) :: Element.t
+
+  def send_keys(element, text) when is_binary(text) do
+    send_keys(element, [text])
+  end
+  def send_keys(element, keys) when is_list(keys) do
+    case Driver.send_keys(element, keys) do
+      {:ok, _} ->
+	element
+      {:error, :stale_reference_error} ->
+	raise Wallaby.StaleReferenceException
+    end
+  end
+
+  @doc """
+  Matches the Element's value with the provided value.
+  """
+  @spec value(Element.t) :: String.t
+
+  def value(element) do
+    attr(element, "value")
+  end
 end

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -281,9 +281,16 @@ defmodule Wallaby.Phantom.Driver do
   @doc """
   Sends a list of key strokes to active element
   """
+  def send_keys(%Session{}=session, keys) when is_list(keys) do
+    check_logs! session, fn ->
+      with {:ok, resp} <- request(:post, "#{session.session_url}/keys", Wallaby.Helpers.KeyCodes.json(keys), encode_json: false),
+           {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+    end
+  end
   def send_keys(parent, keys) when is_list(keys) do
     check_logs! parent, fn ->
-      with {:ok, resp} <- request(:post, "#{parent.session_url}/keys", Wallaby.Helpers.KeyCodes.json(keys), encode_json: false),
+      with {:ok, resp} <- request(:post, "#{parent.url}/value", Wallaby.Helpers.KeyCodes.json(keys), encode_json: false),
            {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
     end

--- a/test/wallaby/element/send_keys_test.exs
+++ b/test/wallaby/element/send_keys_test.exs
@@ -1,0 +1,26 @@
+defmodule Wallaby.Element.SendKeysTest do
+  use Wallaby.SessionCase, async: true
+
+  setup %{session: session} do
+    {:ok, page: visit(session, "forms.html")}
+  end
+
+  @name_field Query.text_field("Name")
+  @email_field Query.text_field("email_field")
+
+  describe "send_keys/2" do
+    test "sends keys to the specified element", %{page: page} do
+      page
+      |> click(@email_field)
+      |> find(@name_field, fn(element) ->
+	assert element
+	|> Element.send_keys("Chris")
+	|> Element.value == "Chris"
+      end)
+      |> find(@email_field, fn(email) ->
+	assert email
+	|> Element.value == ""
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Moving `send_keys/2` and `value/1` to the element module. I've also eliminated the need to explicitly click the element before sending the keys.