### PR TITLE
quote arguments to script, use spawn_executable

### DIFF
--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -68,7 +68,6 @@ defmodule Wallaby.Phantom.Server do
     Application.get_env(:wallaby, :phantomjs_args, "")
     |> case do
       string when is_binary(string) ->
-        # Backwards compatible. Should be deprecated?
         String.split(string)
       list when is_list(list) ->
         list

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -19,4 +19,34 @@ defmodule Wallaby.Phantom.ConfigrationTest do
       assert "test/path/phantomjs" in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
     end
   end
+
+  describe "adding phantom args" do
+    setup do
+      old_env = Application.get_env(:wallaby, :phantomjs_args)
+      context = %{old_env: old_env}
+
+      on_exit fn ->
+        reset_env(context)
+      end
+
+      {:ok, context}
+    end
+
+    defp reset_env(%{old_env: old_env}) do
+      Application.put_env(:wallaby, :phantomjs_args, old_env)
+    end
+
+    test "updates the phantomjs command", context do
+      options = [opt1, opt2] = ["--some-opt=value", "--other-opt"]
+
+      Application.put_env(:wallaby, :phantomjs_args, Enum.join(options, " "))
+      assert opt1 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
+      assert opt2 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
+
+      reset_env(context)
+      Application.put_env(:wallaby, :phantomjs_args, options)
+      assert opt1 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
+      assert opt2 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
+    end
+  end
 end

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -3,10 +3,11 @@ defmodule Wallaby.Phantom.ConfigrationTest do
 
   describe "changing phantom path" do
     setup do
+      old_env = Application.get_env(:wallaby, :phantomjs)
       Application.put_env(:wallaby, :phantomjs, "test/path/phantomjs")
 
       on_exit fn ->
-        Application.put_env(:wallaby, :phantomjs, nil)
+        Application.put_env(:wallaby, :phantomjs, old_env)
       end
     end
 

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -7,7 +7,7 @@ defmodule Wallaby.Phantom.ConfigrationTest do
       Application.put_env(:wallaby, :phantomjs, "test/path/phantomjs")
 
       on_exit fn ->
-        Application.put_env(:wallaby, :phantomjs, old_env)
+        restore_env(:phantomjs, old_env)
       end
     end
 
@@ -33,7 +33,7 @@ defmodule Wallaby.Phantom.ConfigrationTest do
     end
 
     defp reset_env(%{old_env: old_env}) do
-      Application.put_env(:wallaby, :phantomjs_args, old_env)
+      restore_env(:phantomjs_args, old_env)
     end
 
     test "updates the phantomjs command", context do
@@ -48,5 +48,12 @@ defmodule Wallaby.Phantom.ConfigrationTest do
       assert opt1 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
       assert opt2 in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
     end
+  end
+
+  def restore_env(key, nil) do
+    Application.delete_env(:wallaby, key)
+  end
+  def restore_env(key, value) do
+    Application.put_env(:wallaby, key, value)
   end
 end

--- a/test/wallaby/phantom/configure_test.exs
+++ b/test/wallaby/phantom/configure_test.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Phantom.ConfigrationTest do
     end
 
     test "updates the phantomjs command" do
-      assert Wallaby.Phantom.Server.phantomjs_command(1234, '/tmp/dir') =~ ~r/test\/path\/phantomjs/
+      assert "test/path/phantomjs" in Wallaby.Phantom.Server.script_args(1234, '/tmp/dir')
     end
   end
 end


### PR DESCRIPTION
Wallaby was unable so spawn the subprocess when the project path contains a space.
Additional quoting added by using the args option.