### PR TITLE
Take screenshots if `has?` fails.

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -830,8 +830,11 @@ defmodule Wallaby.Browser do
 
   def has?(parent, query) do
     case execute_query(parent, query) do
-      {:ok, _} -> true
-      {:error, _} -> false
+      {:ok, _} ->
+	true
+      {:error, _} ->
+	take_screenshot(parent)
+	false
     end
   end
 

--- a/test/wallaby/browser/screenshot_test.exs
+++ b/test/wallaby/browser/screenshot_test.exs
@@ -1,6 +1,8 @@
 defmodule Wallaby.Browser.ScreenshotTest do
   use Wallaby.SessionCase, async: false
 
+  import Wallaby.Query, only: [css: 1]
+
   setup %{session: session} do
     page =
       session
@@ -67,6 +69,9 @@ defmodule Wallaby.Browser.ScreenshotTest do
     end
     assert File.exists?("#{File.cwd!}/screenshots")
     assert File.ls!("#{File.cwd!}/screenshots") |> Enum.count == 1
+
+    refute has?(page, css(".some-selector-that-does-not-exist"))
+    assert File.ls!("#{File.cwd!}/screenshots") |> Enum.count == 2
 
     File.rm_rf! "#{File.cwd!}/screenshots"
     Application.put_env(:wallaby, :screenshot_on_failure, nil)


### PR DESCRIPTION
This allows us to take screenshots if a `has?` returns false. I'm wondering if this is a good idea since a user might be expecting a false value. For instance if they did a `refute has?(query)`. However, getting automatic screenshots when we fail assertions makes debugging, especially on CI servers, a lot easier.