### PR TITLE
Implement assert_has and refute_has

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -921,10 +921,10 @@ defmodule Wallaby.Browser do
       parent = unquote(parent)
       query  = unquote(query)
 
-      case has?(parent, query) do
-        true ->
+      case execute_query(parent, query) do
+        {:ok, _query_result} ->
           parent
-        false ->
+        {:error, _not_found} ->
           raise Wallaby.ExpectationNotMet,
                 Query.ErrorMessage.message(query, :not_found)
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -903,6 +903,66 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
+  Checks if `query` is present within `parent` and raises if not found.
+
+  Returns the given `parent` if the assertion is correct so that it is easily
+  pipeable.
+
+  ## Examples
+
+      session
+      |> visit("/")
+      |> assert_has(Query.css(".login-button"))
+  """
+  @spec assert_has(parent, Query.t) :: parent
+
+  defmacro assert_has(parent, query) do
+    quote do
+      parent = unquote(parent)
+      query  = unquote(query)
+
+      case has?(parent, query) do
+        true ->
+          parent
+        false ->
+          raise Wallaby.ExpectationNotMet,
+                "Query type '#{query.method}' with selector " <>
+                  "'#{query.selector}' not found"
+      end
+    end
+  end
+
+  @doc """
+  Checks if `query` is not present within `parent` and raises if it is found.
+
+  Returns the given `parent` if the query is not found so that it is easily
+  pipeable.
+
+  ## Examples
+
+      session
+      |> visit("/")
+      |> refute_has(Query.css(".secret-admin-content"))
+  """
+  @spec refute_has(parent, Query.t) :: parent
+
+  defmacro refute_has(parent, query) do
+    quote do
+      parent = unquote(parent)
+      query  = unquote(query)
+
+      case has?(parent, query) do
+        false ->
+          parent
+        true ->
+          raise Wallaby.ExpectationNotMet,
+                "Query type '#{query.method}' with selector " <>
+                  "'#{query.selector}' found but expected not to be there"
+      end
+    end
+  end
+
+  @doc """
   Searches for CSS on the page.
   """
   @spec has_css?(parent, Query.t, String.t) :: boolean()

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -924,7 +924,8 @@ defmodule Wallaby.Browser do
       case execute_query(parent, query) do
         {:ok, _query_result} ->
           parent
-        {:error, _not_found} ->
+        {:error, {:not_found, results}} ->
+          query = %Query{query | result: results}
           raise Wallaby.ExpectationNotMet,
                 Query.ErrorMessage.message(query, :not_found)
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -926,8 +926,8 @@ defmodule Wallaby.Browser do
           parent
         false ->
           raise Wallaby.ExpectationNotMet,
-                "Query type '#{query.method}' with selector " <>
-                  "'#{query.selector}' not found"
+                Query.ErrorMessage.message(query, :not_found)
+
       end
     end
   end
@@ -951,13 +951,12 @@ defmodule Wallaby.Browser do
       parent = unquote(parent)
       query  = unquote(query)
 
-      case has?(parent, query) do
-        false ->
+      case execute_query(parent, query) do
+        {:error, _not_found} ->
           parent
-        true ->
+        {:ok, query} ->
           raise Wallaby.ExpectationNotMet,
-                "Query type '#{query.method}' with selector " <>
-                  "'#{query.selector}' found but expected not to be there"
+                Query.ErrorMessage.message(query, :found)
       end
     end
   end
@@ -1103,7 +1102,7 @@ defmodule Wallaby.Browser do
     end
   end
 
-  defp execute_query(parent, query) do
+  def execute_query(parent, query) do
     retry fn ->
       try do
         with {:ok, query}  <- Query.validate(query),

--- a/lib/wallaby/dsl.ex
+++ b/lib/wallaby/dsl.ex
@@ -7,6 +7,7 @@ defmodule Wallaby.DSL do
       alias Wallaby.Browser
       alias Wallaby.Element
       import Wallaby.Browser
+      require Wallaby.Browser
     end
   end
 end

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -7,9 +7,10 @@ defmodule Wallaby.Query.ErrorMessage do
   @spec message(Query.t, any()) :: String.t
 
   def message(%Query{}=query, :not_found) do
-    """
-    Expected to find #{expected_count(query)}, #{visibility(query)} #{method(query)} '#{query.selector}' but #{result_count(query.result)}, #{visibility(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
-    """
+    "Expected to find #{found_error_message(query)}"
+  end
+  def message(%Query{}=query, :found) do
+    "Expected not to find #{found_error_message(query)}"
   end
   def message(%{method: method, selector: selector}, :label_with_no_for) do
     """
@@ -54,6 +55,12 @@ defmodule Wallaby.Query.ErrorMessage do
     """
     If you expect to find the selector #{times(length(elements))} then you
     should include the `count: #{length(elements)}` option in your finder.
+    """
+  end
+
+  defp found_error_message(query) do
+    """
+    #{expected_count(query)}, #{visibility(query)} #{method(query)} '#{query.selector}' but #{result_count(query.result)}, #{visibility(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
     """
   end
 

--- a/test/wallaby/browser/assert_refute_has_test.exs
+++ b/test/wallaby/browser/assert_refute_has_test.exs
@@ -3,6 +3,7 @@ defmodule Wallaby.Browser.AssertRefuteHasTest do
 
   @found_query Query.css(".user", count: :any)
   @not_found_query Query.css(".something-else")
+  @wrong_exact_found_query Query.css(".user", count: 5)
   describe "assert_has/2" do
     test "passes if the query is present on the page", %{session: session} do
       return = session
@@ -17,6 +18,14 @@ defmodule Wallaby.Browser.AssertRefuteHasTest do
         session
         |> visit("nesting.html")
         |> assert_has(@not_found_query)
+      end
+    end
+
+    test "mentions the count of found vs. expected elements", %{session: session} do
+      assert_raise Wallaby.ExpectationNotMet, ~r/Expected.+ 5.*css.*\.user.*6/i, fn ->
+        session
+        |> visit("nesting.html")
+        |> assert_has(@wrong_exact_found_query)
       end
     end
   end

--- a/test/wallaby/browser/assert_refute_has_test.exs
+++ b/test/wallaby/browser/assert_refute_has_test.exs
@@ -13,7 +13,7 @@ defmodule Wallaby.Browser.AssertRefuteHasTest do
     end
 
     test "raises if the query is not found", %{session: session} do
-      assert_raise Wallaby.ExpectationNotMet, ~r/css.*\.something-else/i, fn ->
+      assert_raise Wallaby.ExpectationNotMet, ~r/Expected.+ 1.*css.*\.something-else.*0/i, fn ->
         session
         |> visit("nesting.html")
         |> assert_has(@not_found_query)
@@ -31,7 +31,7 @@ defmodule Wallaby.Browser.AssertRefuteHasTest do
     end
 
     test "raises if the query is found on the page", %{session: session} do
-      assert_raise Wallaby.ExpectationNotMet, ~r/css.*\.user/i, fn ->
+      assert_raise Wallaby.ExpectationNotMet, ~r/Expected not.+any.*css.*\.user.*6/i, fn ->
         session
         |> visit("nesting.html")
         |> refute_has(@found_query)

--- a/test/wallaby/browser/assert_refute_has_test.exs
+++ b/test/wallaby/browser/assert_refute_has_test.exs
@@ -1,0 +1,41 @@
+defmodule Wallaby.Browser.AssertCssTest do
+  use Wallaby.SessionCase, async: true
+
+  @found_query Query.css(".user", count: :any)
+  @not_found_query Query.css(".something-else")
+  describe "assert_has/2" do
+    test "passes if the query is present on the page", %{session: session} do
+      return = session
+               |> visit("nesting.html")
+               |> assert_has(@found_query)
+
+      assert %Wallaby.Session{} = return
+    end
+
+    test "raises if the query is not found", %{session: session} do
+      assert_raise Wallaby.ExpectationNotMet, ~r/css.*\.something-else/i, fn ->
+        session
+        |> visit("nesting.html")
+        |> assert_has(@not_found_query)
+      end
+    end
+  end
+
+  describe "refute_has/2" do
+    test "passes if the query is not found on the page", %{session: session} do
+      return = session
+               |> visit("nesting.html")
+               |> refute_has(@not_found_query)
+
+      assert %Wallaby.Session{} = return
+    end
+
+    test "raises if the query is found on the page", %{session: session} do
+      assert_raise Wallaby.ExpectationNotMet, ~r/css.*\.user/i, fn ->
+        session
+        |> visit("nesting.html")
+        |> refute_has(@found_query)
+      end
+    end
+  end
+end

--- a/test/wallaby/browser/assert_refute_has_test.exs
+++ b/test/wallaby/browser/assert_refute_has_test.exs
@@ -1,4 +1,4 @@
-defmodule Wallaby.Browser.AssertCssTest do
+defmodule Wallaby.Browser.AssertRefuteHasTest do
   use Wallaby.SessionCase, async: true
 
   @found_query Query.css(".user", count: :any)


### PR DESCRIPTION
* fixes #159
* implemented as macros as it results in a cleaner stack trace

This is also the first time I write a macro for production code, so feel free to review away :)

----

As for macro vs. function I tried out a quick version in our project (different implementation than here, hence less cool error message) and the stack trace is just cleaner:

Function:

```
  1) test logging in logging successfully (Fulfillment.AuthAcceptanceTest)
     test/acceptance/auth_acceptance_test.exs:5
     Expected truthy, got false
     code: has?(parent, query)
     stacktrace:
       (fulfillment) lib/wallaby_helpers.ex:20: WallabyHelpers.assert_has/2
       test/acceptance/auth_acceptance_test.exs:12: (test)
```

Macro:

```
  1) test logging in logging successfully (Fulfillment.AuthAcceptanceTest)
     test/acceptance/auth_acceptance_test.exs:5
     Expected truthy, got false
     code: has?(parent, login_button())
     stacktrace:
       test/acceptance/auth_acceptance_test.exs:12: (test)
```

(it goes directly to the test without the intermediate step where the function is defined).

