### PR TITLE
Use new phantomjs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Application.put_env(:wallaby, :base_url, YourApplication.Endpoint.url)
 Wallaby requires PhantomJS. You can install PhantomJS through NPM or your package manager of choice:
 
 ```
-$ npm install -g phantomjs
+$ npm install -g phantomjs-prebuilt
 ```
 
 Wallaby will use whatever phantomjs you have installed in your path. If you need to specify a specific phantomjs you can pass the path in the configuration:


### PR DESCRIPTION
The original phantomjs package is deprecated and replaced by
phantomjs-prebuilt.

Deprecation notice from the package page:

DEPRECATED

Pre-2.0, this package was published to NPM as phantomjs.
We changed the name to phantomjs-prebuilt at the request of PhantomJS team.

Please update your package references from phantomjs to phantomjs-prebuilt