### PR TITLE
Remove deprecated functions - fill_in

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -155,29 +155,12 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Fills in a "fillable" element with text. Input elements are looked up by id, label text,
-  or name.
+  Fills in an element identified by `query` with `value`.
   """
-  @spec fill_in(element, opts) :: element
   @spec fill_in(parent, Query.t, with: String.t) :: parent
-  @spec fill_in(parent, locator, opts) :: parent
-
-  def fill_in(parent, locator, [{:with, value} | _]=opts) when is_binary(locator) do
-    IO.warn """
-    fill_in/3 with string locators has been deprecated. Please use a query: fill_in(parent, Query.text_field("#{locator}"), with: "#{value}")
-    """
-
-    parent
-    |> find(Query.fillable_field(locator, opts), &(Element.fill_in(&1, with: value)))
-  end
   def fill_in(parent, query, with: value) do
     parent
     |> find(query, &(Element.fill_in(&1, with: value)))
-  end
-  def fill_in(%Element{}=element, with: value) do
-    IO.warn "fill_in/2 has been deprecated. Please use Element.fill_in/2"
-
-    Element.fill_in(element, with: value)
   end
 
   @doc """

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -156,6 +156,15 @@ defmodule Wallaby.Browser do
 
   @doc """
   Fills in an element identified by `query` with `value`.
+
+  All inputs previously present in the input field will be overridden.
+
+  ### Examples
+
+      page
+      |> fill_in(Query.text_field("name"), with: "Chris")
+      |> fill_in(Query.css("#password_field", with: "secret42"))
+
   """
   @spec fill_in(parent, Query.t, with: String.t) :: parent
   def fill_in(parent, query, with: value) do

--- a/test/wallaby/browser/clear_test.exs
+++ b/test/wallaby/browser/clear_test.exs
@@ -7,7 +7,7 @@ defmodule Wallaby.Browser.ClearTest do
       |> visit("forms.html")
       |> find(Query.css("#name_field"))
 
-    fill_in(element, with: "Chris")
+    Element.fill_in(element, with: "Chris")
     assert has_value?(element, "Chris")
 
     clear(element)

--- a/test/wallaby/browser/click_button_test.exs
+++ b/test/wallaby/browser/click_button_test.exs
@@ -65,7 +65,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[button] via button text (resets input via JS)", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -76,7 +76,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[button] via name (resets input via JS)", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -87,7 +87,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[button] via id (resets input via JS)", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -98,7 +98,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[reset] via button text resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -109,7 +109,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[reset] via name resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -120,7 +120,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking button type[reset] via id resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -158,7 +158,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[button] via button text resets input via JS", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -169,7 +169,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[button] via name resets input via JS", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -180,7 +180,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[button] via id resets input via JS", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -191,7 +191,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[reset] via button text resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -202,7 +202,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[reset] via name resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 
@@ -213,7 +213,7 @@ defmodule Wallaby.Browser.Actions.ClickButtonTest do
 
   test "clicking input type[reset] via id resets form", %{page: page} do
     page
-    |> fill_in("name_field", with: "Erlich Bachman")
+    |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
     assert find(page, "#name_field") |> has_value?("Erlich Bachman")
 

--- a/test/wallaby/browser/fill_in_test.exs
+++ b/test/wallaby/browser/fill_in_test.exs
@@ -18,61 +18,62 @@ defmodule Wallaby.Browser.FillInTest do
     |> has_value?("Chris")
   end
 
-  test "filling in input by name", %{page: page} do
-    page
-    |> fill_in("name", with: "Chris")
-
-    assert find(page, "#name_field") |> has_value?("Chris")
-  end
-
   test "filling in input by id", %{page: page} do
     page
-    |> fill_in("name_field", with: "Chris")
+    |> fill_in(Query.css("#name_field"), with: "Chris")
 
-    assert find(page, "#name_field") |> has_value?("Chris")
+    assert find(page, Query.css("#name_field")) |> has_value?("Chris")
   end
 
   test "fill_in accepts numbers", %{page: page} do
     page
-    |> fill_in("password", with: 1234)
+    |> fill_in(Query.text_field("password"), with: 1234)
 
-    assert find(page, "#password_field") |> has_value?("1234")
+    assert find(page, Query.css("#password_field")) |> has_value?("1234")
   end
 
   test "filling in multiple inputs", %{page: page} do
     page
-    |> fill_in("name", with: "Alex")
-    |> fill_in("email", with: "alex@example.com")
+    |> fill_in(Query.text_field("name"), with: "Alex")
+    |> fill_in(Query.text_field("email"), with: "alex@example.com")
 
-    assert find(page, "#name_field")  |> has_value?("Alex")
-    assert find(page, "#email_field") |> has_value?("alex@example.com")
+    assert page
+           |> find(Query.css("#name_field"))
+           |> has_value?("Alex")
+    assert page
+           |> find(Query.css("#email_field"))
+           |> has_value?("alex@example.com")
   end
 
   test "fill_in replaces all of the text", %{page: page} do
     page
-    |> fill_in("name", with: "Chris")
-    |> fill_in("name", with: "Alex")
+    |> fill_in(Query.text_field("name"), with: "Chris")
+    |> fill_in(Query.text_field("name"), with: "Alex")
 
-    assert find(page, "#name_field") |> has_value?("Alex")
+    assert find(page, Query.css("#name_field")) |> has_value?("Alex")
   end
 
   test "waits until the input appears", %{page: page} do
-    assert fill_in(page, "Hidden Text Field", with: "Test Label Text")
+    fill_in(page, Query.text_field("Hidden Text Field"), with: "Test Label Text")
+
+    assert page
+           |> find(Query.css("#hidden-text-field-id"))
+           |> has_value?("Test Label Text")
   end
 
   test "checks for labels without for attributes", %{page: page} do
     assert_raise Wallaby.QueryError, ~r/label has no 'for'/, fn ->
-      fill_in(page, "Input with bad label", with: "Test")
+      fill_in(page, Query.text_field("Input with bad label"), with: "Test")
     end
   end
 
   test "checks for mismatched ids on labels", %{page: page} do
     assert_raise Wallaby.QueryError, ~r/but the label's 'for' attribute/, fn ->
-      fill_in(page, "Input with bad id", with: "Test")
+      fill_in(page, Query.text_field("Input with bad id"), with: "Test")
     end
   end
 
   test "escapes quotes", %{page: page} do
-    assert fill_in(page, "I'm a text field", with: "Stuff")
+    assert fill_in(page, Query.text_field("I'm a text field"), with: "Stuff")
   end
 end


### PR DESCRIPTION
A first step toward #177 

As this is the first one I thought I'd keep it small and simple (I just started with the first function that had an `IO.warn` in there) so we can see if this is a good template for removing outdated functions :)