### PR TITLE
make execute_script return session instead of script result

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -527,13 +527,30 @@ defmodule Wallaby.Browser do
 
   @doc """
   Executes javascript synchoronously, taking as arguments the script to execute,
-  and optionally a list of arguments available in the script via `arguments`
+  an optional list of arguments available in the script via `arguments`, and an
+  optional callback function with the result of script execution as a parameter.
   """
+  @spec execute_script(parent, String.t) :: parent
   @spec execute_script(parent, String.t, list) :: parent
+  @spec execute_script(parent, String.t, ((binary()) -> any())) :: parent
+  @spec execute_script(parent, String.t, list, ((binary()) -> any())) :: parent
 
-  def execute_script(session, script, arguments \\ []) do
+
+  def execute_script(session, script) do
+    execute_script(session, script, [])
+  end
+
+  def execute_script(session, script, arguments) when is_list(arguments) do
+    execute_script(session, script, arguments, fn(value) -> end )
+  end
+  def execute_script(session, script, callback) when is_function(callback) do
+    execute_script(session, script, [], callback)
+  end
+
+  def execute_script(session, script, arguments, callback) when is_list(arguments) and is_function(callback) do
     {:ok, value} = Driver.execute_script(session, script, arguments)
-    value
+    callback.(value)
+    session
   end
 
   @doc """

--- a/test/wallaby/browser/execute_script_test.exs
+++ b/test/wallaby/browser/execute_script_test.exs
@@ -1,22 +1,38 @@
 defmodule Wallaby.Browser.ExecuteScriptTest do
   use Wallaby.SessionCase, async: true
 
+  @script """
+    var element = document.createElement("div")
+    element.id = "new-element"
+    var text = document.createTextNode(arguments[0])
+    element.appendChild(text)
+    document.body.appendChild(element)
+    return arguments[1]
+  """
   test "executing scripts with arguments and returning", %{session: session} do
-    script = """
-      var element = document.createElement("div")
-      element.id = "new-element"
-      var text = document.createTextNode(arguments[0])
-      element.appendChild(text)
-      document.body.appendChild(element)
-      return arguments[1]
-    """
+
+    assert session
+      |> visit("page_1.html")
+      |> execute_script(@script, ["now you see me", "return value"])
+      |> find(Query.css("#new-element"))
+      |> text == "now you see me"
+  end
+
+  test "executing scripts with arguments and callback returns session", %{session: session} do
+
 
     result =
       session
       |> visit("page_1.html")
-      |> execute_script(script, ["now you see me", "return value"])
+      |> execute_script(@script, ["now you see me", "return value"], fn(value) ->
+           assert value == "return value"
+           send self, {:callback, value}
+         end)
 
-    assert result == "return value"
+    assert result == session
+
+    assert_received{:callback, "return value"}
+
     assert session
     |> find(Query.css("#new-element"))
     |> text == "now you see me"


### PR DESCRIPTION
This resolves #172 by changing ```execute_script``` to return the session passed to it and allowing a callback to be passed to ```execute_script```  which has the script's return value as its parameter.