### PR TITLE
Fix dialyzer errors and add dialyzer to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: elixir
 elixir: 1.4.0
 otp_release: 19.2
+cache:
+  directories:
+    - _build
+    - deps
+before_script:
+  - MIX_ENV=test mix compile --warnings-as-errors
+  - mix dialyzer --plt
 
 script:
   - mix coveralls.travis
+  - mix dialyzer --halt-exit-status
 
 matrix:
   include:

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -906,7 +906,6 @@ defmodule Wallaby.Browser do
       |> visit("/")
       |> assert_has(Query.css(".login-button"))
   """
-  @spec assert_has(parent, Query.t) :: parent
 
   defmacro assert_has(parent, query) do
     quote do
@@ -937,7 +936,6 @@ defmodule Wallaby.Browser do
       |> visit("/")
       |> refute_has(Query.css(".secret-admin-content"))
   """
-  @spec refute_has(parent, Query.t) :: parent
 
   defmacro refute_has(parent, query) do
     quote do

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -542,8 +542,8 @@ defmodule Wallaby.Browser do
       iex> Wallaby.Session.send_keys(session, [:enter])
       iex> Wallaby.Session.send_keys(session, [:shift, :enter])
   """
-  @spec send_keys(parent, Query.t, list(atom) | String.t) :: parent
-  @spec send_keys(parent, list(atom) | String.t) :: parent
+  @spec send_keys(parent, Query.t, Element.keys_to_send) :: parent
+  @spec send_keys(parent, Element.keys_to_send) :: parent
 
   def send_keys(parent, query, list) do
     find(parent, query, fn(element) ->

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -32,6 +32,7 @@ defmodule Wallaby.Element do
   @opaque value :: String.t | number()
 
   @type attr :: String.t
+  @type keys_to_send :: String.t | list(atom | String.t)
   @type t :: %__MODULE__{
     session_url: String.t,
     url: String.t,
@@ -159,7 +160,7 @@ defmodule Wallaby.Element do
   @doc """
   Sends keys to the element.
   """
-  @spec send_keys(t, String.t | list(atom | String.t)) :: t
+  @spec send_keys(t, keys_to_send) :: t
 
   def send_keys(element, text) when is_binary(text) do
     send_keys(element, [text])

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -25,7 +25,7 @@ defmodule Wallaby.Phantom.Server do
     port = find_available_port()
     local_storage = tmp_local_storage()
 
-    Port.open({:spawn_executable, script_path()},
+    Port.open({:spawn_executable, String.to_charlist(script_path())},
       [:binary, :stream, :use_stdio, :exit_status, args: script_args(port, local_storage)])
 
     {:ok, %{running: false, awaiting_url: [], base_url: "http://localhost:#{port}/", local_storage: local_storage}}

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule Wallaby.Mixfile do
      preferred_cli_env: [
        "coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test,
        "coveralls.html": :test, "coveralls.travis": :test
-     ]
+     ],
+    dialyzer: [plt_add_apps: [:inets]]
    ]
   end
 


### PR DESCRIPTION
These changes fix a few dialyzer errors in the project and also run dialyzer during the Travis CI build. I made a couple notable changes below

I removed the typespec from the `assert_has` and `refute_has` macros, because dialyzer was raising a warning on them. I checked in the Elixir, Ecto, Plug and Phoenix libraries and couldn't find a single example of where someone documented macros using a typespec.

I also changed the call to `Port.open/2` so it passes a charlist as the second element in the `{:spawn_executable, _}` tuple. This call passed directly to the `open_port/2` erlang function and expects an erlang string.

Please let me know what you think and if there's any changes you'd like me to make.
