### PR TITLE
Removed due to travis fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ cache:
     - deps
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
-  - mix dialyzer --plt
 
 script:
   - mix coveralls.travis
-  - mix dialyzer --halt-exit-status
 
 matrix:
   include:


### PR DESCRIPTION
* Example: https://travis-ci.org/keathley/wallaby/jobs/218338365
* not sure what's happening... timeout maybe?

Checking 380 modules in dialyxir_erlang-19.2_elixir-1.4.0_deps-dev.plt

Adding 265 modules to dialyxir_erlang-19.2_elixir-1.4.0_deps-dev.plt

/home/travis/.travis/job_stages: line 53:  2871 Killed                  mix dialyzer --plt

The command "mix dialyzer --plt" failed and exited with 137 during .

Any idea @aaronrenner ?