### PR TITLE
Fix dialyzer on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: elixir
 elixir: 1.4.0
 otp_release: 19.2
+# Run in bigger container so we don't run out of memory generating the plt
+sudo: required
 cache:
   directories:
     - _build
     - deps
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
+  - travis_wait mix dialyzer --plt
 
 script:
   - mix coveralls.travis
+  - mix dialyzer --halt-exit-status
 
 matrix:
   include:


### PR DESCRIPTION
This runs the build with `sudo: required` so it runs on a larger vm with [7.5GB of memory](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments), so mix dialyzer --plt doesn't run the vm out of memory and exit with code 137.

This also runs wraps the `mix dialyzer --plt` in the `travis_wait` command so if it doesn't output any log statements in 10 minutes, the build won't timeout.

Finally, the build is already being cached, so the only time the PLT needs to be built is on a fresh cache, or if the build matrix is changed.

Fixes #186.