### PR TITLE
Fix typespec for Session struct

### DIFF
--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -41,7 +41,7 @@ defmodule Wallaby.Session do
   """
 
   @type t :: %__MODULE__{
-    id: integer(),
+    id: String.t,
     session_url: String.t,
     url: String.t,
     server: pid(),


### PR DESCRIPTION
I just ran the tests and session.id is a uuid string, not an integer. Here is a sample session struct I received when running the test suite.

```
%Wallaby.Session{id: "9ae736b0-1958-11e7-9573-6f21b8c89bef", screenshots: [],
  server: #PID<0.228.0>,
  session_url: "http://localhost:59483/session/9ae736b0-1958-11e7-9573-6f21b8c89bef",
  url: "http://localhost:59483/session/9ae736b0-1958-11e7-9573-6f21b8c89bef"}}
```
