### PR TITLE
Update elixir versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: 1.4.0
+elixir: 1.4.2
 otp_release: 19.2
 # Run in bigger container so we don't run out of memory generating the plt
 sudo: required
@@ -17,7 +17,7 @@ script:
 
 matrix:
   include:
-    - elixir: 1.3.2
+    - elixir: 1.3.4
       otp_release: 18.2.1
 
 before_install:


### PR DESCRIPTION
Being up to date with the good ol patch levels.

Which reminds me, is there a reason we don't just run both elixir versions against both otp releases? Being very nice to travis? :) @keathley