### PR TITLE
Make Phantom.Server escript compatible

### DIFF
--- a/priv/run_phantom.sh
+++ b/priv/run_phantom.sh
@@ -1,5 +1,9 @@
-#!/usr/bin/env sh
-$@ &
-DRIVER=$!
-read CMD
-kill $DRIVER
+#!/bin/sh
+"$@" &
+pid=$!
+$(
+  while read line ; do
+    :
+  done
+  kill -KILL $pid
+)


### PR DESCRIPTION
This allows Wallaby.Phantom.Server to run when priv/run_phantom.sh isn't available (like when running as an escript). Since we can't directly run the script, we need to run /bin/sh with the arguments we want to use and pipe the contents of run_phantom.sh in via stdin. This is almost the
same script as in the Elixir Port docs (https://hexdocs.pm/elixir/Port.html#module-zombie-processes), but it runs the command in the background and then listens for stdin to close
and kills the process from a subshell.

I have confirmed this shuts down phantom in the following situations:

* ^C+^C in IEx
* causing the beam to core dump by overflowing the atom table
* running kill -9 on the beam.

Huge thanks to @koudelka for all of his help coming up with this approach. Please let me know if you see any areas where it can be improved.

Fixes #192