### PR TITLE
Test to ensure StaleReferenceException is raised

### DIFF
--- a/test/wallaby/browser/stale_nodes_test.exs
+++ b/test/wallaby/browser/stale_nodes_test.exs
@@ -10,5 +10,18 @@ defmodule Wallaby.Browser.StaleElementsTest do
 
       assert element
     end
+
+    test "when a DOM element disappears", %{session: session} do
+      element =
+        session
+        |> visit("stale_nodes.html")
+        |> find(Query.css("#removed-node"))
+
+      Process.sleep(400) # let the node disappear via javascript
+
+      assert_raise Wallaby.StaleReferenceException, fn ->
+        Element.value(element)
+      end
+    end
   end
 end


### PR DESCRIPTION
I was curious what the response looked like from PhantomJS when we get a StaleReferenceException found out we didn't have a test triggering it.