### PR TITLE
Extracted Wallaby.Webdriver.Client module

### DIFF
--- a/lib/wallaby/phantom/webdriver/client.ex
+++ b/lib/wallaby/phantom/webdriver/client.ex
@@ -1,0 +1,16 @@
+defmodule Wallaby.Phantom.Webdriver.Client do
+  @moduledoc false
+
+  alias Wallaby.Session
+  alias Wallaby.Webdriver.Client
+
+  @doc """
+  Executes javascript using phantomjs specific endpoint
+  """
+  @spec execute_script(Session.t, String.t, list(any)) :: {:ok, any}
+  def execute_script(session, script, arguments) do
+    with {:ok, resp} <- Client.request(:post, "#{session.session_url}/phantom/execute", %{script: script, args: arguments}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+end

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -94,6 +94,8 @@ defmodule Wallaby.Query do
     result: result(),
   }
 
+  @type compiled_query :: {:css | :xpath, String.t}
+
 
   def css(selector, opts \\ []) do
     %Query{
@@ -212,6 +214,7 @@ defmodule Wallaby.Query do
     end
   end
 
+  @spec compile(t) :: compiled_query
   def compile(%{method: :css, selector: selector}), do: {:css, selector}
   def compile(%{method: :xpath, selector: selector}), do: {:xpath, selector}
   def compile(%{method: :link, selector: selector}), do: {:xpath, XPath.link(selector)}

--- a/lib/wallaby/webdriver/client.ex
+++ b/lib/wallaby/webdriver/client.ex
@@ -1,0 +1,382 @@
+defmodule Wallaby.Webdriver.Client do
+  @moduledoc false
+  alias Wallaby.{Element, Query, Session}
+
+  @type http_method :: :post | :get | :delete
+  @type url :: String.t
+
+  @doc """
+  Create a session with the base url.
+  """
+  @spec create_session(String.t, map) :: {:ok, map}
+  def create_session(base_url, capabilities) do
+    params = %{desiredCapabilities: capabilities}
+
+    request(:post, "#{base_url}session", params)
+  end
+
+  @doc """
+  Deletes a session with the driver.
+  """
+  @spec delete_session(Session.t | Element.t) :: {:ok, map}
+  def delete_session(session) do
+    request(:delete, session.session_url, %{})
+  end
+
+  @doc """
+  Finds an element on the page for a session. If an element is provided then
+  the query will be scoped to within that element.
+  """
+  @spec find_elements(Session.t | Element.t, Query.compiled_query) :: {:ok, [Element.t]}
+  def find_elements(parent, locator) do
+    with {:ok, resp} <- request(:post, parent.url <> "/elements", to_params(locator)),
+          {:ok, elements} <- Map.fetch(resp, "value"),
+          elements <- Enum.map(elements, &(cast_as_element(parent, &1))),
+      do: {:ok, elements}
+  end
+
+  @doc """
+  Sets the value of an element.
+  """
+  @spec set_value(Element.t, String.t) :: {:ok, nil}
+  def set_value(%Element{url: url}, value) do
+    with  {:ok, resp} <- request(:post, "#{url}/value", %{value: [value]}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Clears the value in an element
+  """
+  @spec clear(Element.t) :: {:ok, nil}
+  def clear(%Element{url: url}) do
+    with {:ok, resp} <- request(:post, "#{url}/clear"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Clicks an element
+  """
+  @spec click(Element.t) :: {:ok, map}
+  def click(%Element{url: url}) do
+    with  {:ok, resp} <- request(:post, "#{url}/click"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the text for an element
+  """
+  @spec text(Element.t) :: {:ok, String.t}
+  def text(element) do
+    with  {:ok, resp} <- request(:get, "#{element.url}/text"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the title of the current page.
+  """
+  @spec page_title(Session.t) :: {:ok, String.t}
+  def page_title(session) do
+    with  {:ok, resp} <- request(:get, "#{session.url}/title"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the value of an elements attribute
+  """
+  @spec attribute(Element.t, String.t) :: {:ok, String.t}
+  def attribute(element, name) do
+    with {:ok, resp}  <- request(:get, "#{element.url}/attribute/#{name}"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Visit a specific page.
+  """
+  @spec visit(Session.t, String.t) :: {:ok, map}
+  def visit(session, path) do
+    with {:ok, resp} <- request(:post, "#{session.url}/url", %{url: path}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the current url.
+  """
+  @spec current_url(Session.t) :: {:ok, String.t}
+  def current_url(session) do
+    with  {:ok, resp} <- request(:get, "#{session.url}/url"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the current url or nil.
+  """
+  @spec current_url!(Session.t) :: String.t | nil
+  def current_url!(session) do
+    request!(:get, "#{session.url}/url")
+    |> Map.get("value")
+  end
+
+  @doc """
+  Gets the current path or nil.
+  """
+  @spec current_path!(Session.t) :: String.t | nil
+  def current_path!(session) do
+    session
+    |> current_url!
+    |> URI.parse
+    |> Map.get(:path)
+  end
+
+  @doc """
+  Gets the selected value of the element.
+
+  For Checkboxes and Radio buttons it returns the selected option.
+  For options selects it returns the selected option
+  """
+  @spec selected(Element.t) :: {:ok, boolean} | {:error, :stale_reference_error}
+  def selected(element) do
+    with {:ok, resp} <- request(:get, "#{element.url}/selected"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Checks if the element is being displayed.
+
+  This is based on what is available in phantom and doesn't match the current
+  specification.
+  """
+  @spec displayed(Element.t) :: {:ok, boolean} | {:error, :stale_reference_error}
+  def displayed(element) do
+    with {:ok, resp} <- request(:get, "#{element.url}/displayed"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the size of a element.
+
+  This is non-standard and only works in Phantom.
+  """
+  @spec size(Element.t) :: {:ok, any}
+  def size(element) do
+    with {:ok, resp} <- request(:get, "#{element.url}/size"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the height, width, x, and y position of an Element.
+
+  This is based on the standard but currently is un-supported by Phantom.
+  """
+  @spec rect(Element.t) :: {:ok, any}
+  def rect(element) do
+    with {:ok, resp} <- request(:get, "#{element.url}/rect"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Takes a screenshot.
+  """
+  @spec take_screenshot(Session.t) :: binary
+  def take_screenshot(session) do
+    with {:ok, resp}   <- request(:get, "#{session.url}/screenshot"),
+          {:ok, value}  <- Map.fetch(resp, "value"),
+          decoded_value <- :base64.decode(value),
+      do: decoded_value
+  end
+
+  @doc """
+  Gets the cookies for a session.
+  """
+  @spec cookies(Session.t) :: {:ok, [map]}
+  def cookies(session) do
+    with {:ok, resp}  <- request(:get, "#{session.url}/cookie"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Sets a cookie for the session.
+  """
+  @spec set_cookie(Session.t, String.t, String.t) :: {:ok, []}
+  def set_cookie(session, key, value) do
+      with {:ok, resp}  <- request(:post, "#{session.url}/cookie", %{cookie: %{name: key, value: value}}),
+           {:ok, value} <- Map.fetch(resp, "value"),
+       do: {:ok, value}
+  end
+
+  @doc """
+  Sets the size of the window.
+  """
+  @spec set_window_size(Session.t, String.t, non_neg_integer, non_neg_integer) :: {:ok, map}
+  def set_window_size(session, window_handle, width, height) do
+    with {:ok, resp} <- request(:post, "#{session.url}/window/#{window_handle}/size", %{width: width, height: height}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Gets the size of the window
+  """
+  @spec get_window_size(Session.t, String.t) :: {:ok, map}
+  def get_window_size(session, window_handle) do
+    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/size"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Executes javascript synchoronously, taking as arguments the script to execute,
+  and optionally a list of arguments available in the script via `arguments`
+  """
+  @spec execute_script(Session.t | Element.t, String.t, Keyword.t) :: {:ok, any}
+  def execute_script(session, script, arguments \\ []) do
+    with {:ok, resp} <- request(:post, "#{session.session_url}/execute", %{script: script, args: arguments}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Sends a list of key strokes to active element
+  """
+  @spec send_keys(Session.t, [String.t | atom]) :: {:ok, nil}
+  def send_keys(%Session{}=session, keys) when is_list(keys) do
+    with {:ok, resp} <- request(:post, "#{session.session_url}/keys", Wallaby.Helpers.KeyCodes.json(keys), encode_json: false),
+          {:ok, value} <- Map.fetch(resp, "value"),
+    do: {:ok, value}
+  end
+  def send_keys(parent, keys) when is_list(keys) do
+    with {:ok, resp} <- request(:post, "#{parent.url}/value", Wallaby.Helpers.KeyCodes.json(keys), encode_json: false),
+          {:ok, value} <- Map.fetch(resp, "value"),
+    do: {:ok, value}
+  end
+
+  @doc """
+  Retrieves logs from the browser
+  """
+  @spec log(Session.t | Element.t) :: {:ok, [map]}
+  def log(session) do
+    with {:ok, resp} <- request(:post, "#{session.session_url}/log", %{type: "browser"}),
+         {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Retrieves the current page source from session
+  """
+  @spec page_source(Session.t) :: {:ok, String.t}
+  def page_source(session) do
+    with  {:ok, resp} <- request(:get, "#{session.url}/source"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Retrieves the window handle for from session
+  """
+  @spec window_handle(Session.t) :: String.t
+  def window_handle(session) do
+    with  {:ok, resp} <- request(:get, "#{session.url}/window_handle"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: value
+  end
+
+  @type request_opts :: {:encode_json, boolean}
+
+  @doc """
+  Low-level function that sends a request to the webdriver API and parses the
+  response.
+  """
+  @spec request(http_method, url, map | String.t, [request_opts]) ::
+    {:ok, any} | {:error, :stale_reference_error | :invalid_selector}
+  def request(method, url, params \\ %{}, opts \\ [])
+  def request(method, url, params, _opts) when map_size(params) == 0 do
+    make_request(method, url, "")
+  end
+  def request(method, url, params, [{:encode_json, false} | _]) do
+    make_request(method, url, params)
+  end
+  def request(method, url, params, _opts) do
+    make_request(method, url, Poison.encode!(params))
+  end
+
+  @doc """
+  Low-level function that sends a request to the webdriver API and
+  raises an exception if an error occurs.
+  """
+  @spec request!(http_method, url) :: any
+  def request!(method, url) do
+    make_request!(method, url, "")
+  end
+
+  defp make_request(method, url, body) do
+    with {:ok, response} <- HTTPoison.request(method, url, body, headers(), request_opts()),
+         {:ok, decoded} <- Poison.decode(response.body),
+         {:ok, validated} <- check_for_response_errors(decoded),
+      do: {:ok, validated}
+  end
+
+  defp make_request!(method, url, body) do
+    case make_request(method, url, body) do
+      {:ok, resp} ->
+        resp
+
+      {:error, :stale_reference_error} ->
+        raise Wallaby.StaleReferenceException
+
+      {:error, :invalid_selector} ->
+        raise Wallaby.InvalidSelector, Poison.decode!(body)
+
+      {:error, e} ->
+        raise "There was an error calling: #{url} -> #{e.reason}"
+    end
+  end
+
+  defp request_opts do
+    [timeout: :infinity, recv_timeout: :infinity]
+  end
+
+  defp headers do
+    [{"Accept", "application/json"},
+      {"Content-Type", "application/json"}]
+  end
+
+  defp check_for_response_errors(response) do
+    case Map.get(response, "value") do
+      %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
+        {:error, :stale_reference_error}
+      %{"class" => "org.openqa.selenium.InvalidSelectorException"} ->
+        {:error, :invalid_selector}
+      _ ->
+        {:ok, response}
+    end
+  end
+
+  defp to_params({:xpath, xpath}) do
+    %{using: "xpath", value: xpath}
+  end
+  defp to_params({:css, css}) do
+    %{using: "css selector", value: css}
+  end
+
+  @spec cast_as_element(Session.t | Element.t, map) :: Element.t
+  defp cast_as_element(parent, %{"ELEMENT" => id}) do
+    %Wallaby.Element{
+      id: id,
+      session_url: parent.session_url,
+      url: parent.session_url <> "/element/#{id}",
+      parent: parent,
+    }
+  end
+end

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -6,36 +6,6 @@ defmodule Wallaby.Phantom.DriverTest do
 
   @window_handle_id "bdc333b0-1989-11e7-a2c3-d1d2d92b0e58"
 
-  describe "create_session/2" do
-    test "sends the correct request to the webdriver backend", %{bypass: bypass} do
-      base_url = bypass_url(bypass) <> "/"
-      new_session_id = "abc123"
-      capabilities = %{
-        "platform" => "OS X",
-        "browser" => "chrome"
-      }
-
-      Bypass.expect bypass, fn conn ->
-        conn = parse_body(conn)
-        assert "POST" == conn.method
-        assert "/session" == conn.request_path
-        assert %{"desiredCapabilities" => capabilities} == conn.body_params
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{new_session_id}",
-          "status": 0,
-          "value": {
-            "acceptSslCerts": false,
-            "browserName": "phantomjs"
-          }
-        }>)
-      end
-
-      assert {:ok, response} = Driver.create_session(base_url, capabilities)
-      assert %{"sessionId" => ^new_session_id} =  response
-    end
-  end
-
   describe "delete/1" do
     test "sends a delete request to Session.session_url", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)

--- a/test/wallaby/phantom/webdriver/client_test.exs
+++ b/test/wallaby/phantom/webdriver/client_test.exs
@@ -1,0 +1,41 @@
+defmodule Wallaby.Phantom.Webdriver.ClientTest do
+  use Wallaby.HttpClientCase, async: true
+
+  alias Wallaby.Phantom.Webdriver.Client
+  alias Wallaby.Session
+
+
+  describe "execute_script/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/phantom/execute"
+        assert conn.body_params == %{
+        "script" => "localStorage.clear()",
+        "args" => [2, "a"]}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": ["ok", null]
+        }>)
+      end
+
+      assert {:ok, ["ok", nil]} = Client.execute_script(session, "localStorage.clear()", [2, "a"])
+    end
+  end
+
+  defp handle_request(bypass, handler_fn) do
+    Bypass.expect bypass, fn conn ->
+      conn |> parse_body |> handler_fn.()
+    end
+  end
+
+  defp build_session_for_bypass(bypass, session_id \\ "my-sample-session") do
+    session_url = bypass_url(bypass, "/session/#{session_id}")
+
+    %Session{id: session_id, session_url: session_url, url: session_url}
+  end
+end

--- a/test/wallaby/webdriver/client_test.exs
+++ b/test/wallaby/webdriver/client_test.exs
@@ -1,0 +1,760 @@
+defmodule Wallaby.Webdriver.ClientTest do
+  use Wallaby.HttpClientCase, async: true
+
+  alias Wallaby.Webdriver.Client
+  alias Wallaby.{Element, Query, Session}
+
+  describe "request/4" do
+    test "sends the request with the correct params and headers", %{bypass: bypass} do
+      Bypass.expect bypass, fn conn ->
+        conn = parse_body(conn)
+        assert conn.method == "POST"
+        assert conn.request_path == "/my_url"
+        assert conn.body_params == %{"hello" => "world"}
+        assert get_req_header(conn, "accept") == ["application/json"]
+        assert get_req_header(conn, "content-type") == ["application/json"]
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "abc123",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, _} = Client.request(:post, bypass_url(bypass, "/my_url"), %{hello: "world"})
+    end
+
+    test "with a 200 status response", %{bypass: bypass} do
+      Bypass.expect bypass, fn conn ->
+        send_resp(conn, 200, ~s<{
+          "sessionId": "abc123",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      {:ok, response} = Client.request(:post, bypass_url(bypass, "/my_url"))
+      assert response == %{
+        "sessionId" => "abc123",
+        "status" => 0,
+        "value" => nil
+      }
+    end
+
+    test "with a 500 response and StaleElementReferenceException", %{bypass: bypass} do
+      Bypass.expect bypass, fn conn ->
+        send_resp(conn, 500, ~s<{
+          "sessionId": "abc123",
+          "status": 10,
+          "value": {
+            "class": "org.openqa.selenium.StaleElementReferenceException"
+          }
+        }>)
+      end
+
+      assert {:error, :stale_reference_error} =
+        Client.request(:post, bypass_url(bypass, "/my_url"))
+    end
+  end
+
+  describe "request!/2" do
+    test "with a 200 status response", %{bypass: bypass} do
+      Bypass.expect bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/my_url"
+        assert get_req_header(conn, "accept") == ["application/json"]
+        assert get_req_header(conn, "content-type") == ["application/json"]
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "abc123",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      response = Client.request!(:post, bypass_url(bypass, "/my_url"))
+      assert response == %{
+        "sessionId" => "abc123",
+        "status" => 0,
+        "value" => nil
+      }
+    end
+
+    test "with a 500 response and StaleElementReferenceException", %{bypass: bypass} do
+      Bypass.expect bypass, fn conn ->
+        send_resp(conn, 500, ~s<{
+          "sessionId": "abc123",
+          "status": 10,
+          "value": {
+            "class": "org.openqa.selenium.StaleElementReferenceException"
+          }
+        }>)
+      end
+
+      assert_raise Wallaby.StaleReferenceException, fn ->
+        Client.request!(:post, bypass_url(bypass, "/my_url"))
+      end
+    end
+  end
+
+  describe "create_session/2" do
+    test "sends the correct request to the webdriver backend", %{bypass: bypass} do
+      base_url = bypass_url(bypass) <> "/"
+      new_session_id = "abc123"
+      capabilities = %{
+        "platform" => "OS X",
+        "browser" => "chrome"
+      }
+
+      handle_request bypass, fn conn ->
+        assert "POST" == conn.method
+        assert "/session" == conn.request_path
+        assert %{"desiredCapabilities" => capabilities} == conn.body_params
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{new_session_id}",
+          "status": 0,
+          "value": {
+            "acceptSslCerts": false,
+            "browserName": "phantomjs"
+          }
+        }>)
+      end
+
+      assert {:ok, response} = Client.create_session(base_url, capabilities)
+      assert %{"sessionId" => ^new_session_id} =  response
+    end
+  end
+
+  describe "delete_session/1" do
+    test "sends a delete request to Session.session_url", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      handle_request bypass, fn conn ->
+        assert "DELETE" == conn.method
+        assert "/session/#{session.id}" == conn.request_path
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, response} = Client.delete_session(session)
+      assert response == %{
+        "sessionId" => session.id,
+        "status" => 0,
+        "value" => %{},
+      }
+    end
+  end
+
+  describe "find_elements/2" do
+    test "with a Session as the parent", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element_id = ":wdc:1491326583887"
+      query = ".blue" |> Query.css |> Query.compile
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/elements"
+        assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": [{"ELEMENT": "#{element_id}"}]
+        }>)
+      end
+
+      assert {:ok, [element]} = Client.find_elements(session, query)
+      assert element == %Element{
+        id: element_id,
+        parent: session,
+        session_url: session.url,
+        url: "#{session.url}/element/#{element_id}",
+      }
+    end
+
+    test "with an Element as the parent", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      parent_element = build_element_for_session(session)
+      element_id = ":wdc:1491326583887"
+      query = ".blue" |> Query.css |> Query.compile
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/element/#{parent_element.id}/elements"
+        assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": [{"ELEMENT": "#{element_id}"}]
+        }>)
+      end
+
+      assert {:ok, [element]} = Client.find_elements(parent_element, query)
+      assert element == %Element{
+        id: element_id,
+        parent: parent_element,
+        session_url: session.url,
+        url: "#{session.url}/element/#{element_id}",
+      }
+    end
+  end
+
+  describe "set_value/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+      value = "hello world"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/value"
+        assert conn.body_params == %{"value" => [value]}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, nil} = Client.set_value(element, value)
+    end
+  end
+
+  describe "clear/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/clear"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, nil} = Client.clear(element)
+    end
+  end
+
+  describe "click/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/click"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.click(element)
+    end
+  end
+
+  describe "text/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/text"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": ""
+        }>)
+      end
+
+      assert {:ok, ""} = Client.text(element)
+    end
+  end
+
+  describe "page_title/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      page_title = "Wallaby rocks"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/title"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{page_title}"
+        }>)
+      end
+
+      assert {:ok, ^page_title} = Client.page_title(session)
+    end
+  end
+
+  describe "attribute/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+      attribute_name = "name"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "password"
+        }>)
+      end
+
+      assert {:ok, "password"} = Client.attribute(element, "name")
+    end
+  end
+
+  describe "visit/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      url = "http://www.google.com"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/url"
+        assert conn.body_params == %{"url" => url}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.visit(session, url)
+    end
+  end
+
+  describe "current_url/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      url = "http://www.google.com"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/url"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{url}"
+        }>)
+      end
+
+      assert {:ok, ^url} = Client.current_url(session)
+    end
+  end
+
+  describe "current_url!/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      url = "http://www.google.com"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/url"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{url}"
+        }>)
+      end
+
+      assert ^url = Client.current_url!(session)
+    end
+  end
+
+  describe "current_path!/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      url = "http://www.google.com/search"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/url"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{url}"
+        }>)
+      end
+
+      assert "/search" = Client.current_path!(session)
+    end
+  end
+
+  describe "selected/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/selected"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": true
+        }>)
+      end
+
+      assert {:ok, true} = Client.selected(element)
+    end
+  end
+
+  describe "displayed/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": true
+        }>)
+      end
+
+      assert {:ok, true} = Client.displayed(element)
+    end
+
+    test "with a stale reference exception", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed"
+
+        send_resp(conn, 500, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 10,
+          "value": {
+            "class": "org.openqa.selenium.StaleElementReferenceException"
+          }
+        }>)
+      end
+
+      assert {:error, :stale_reference_error} = Client.displayed(element)
+    end
+  end
+
+  describe "size/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/size"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "not quite sure"
+        }>)
+      end
+
+      assert {:ok, "not quite sure"} = Client.size(element)
+    end
+  end
+
+  describe "rect/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/rect"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "not quite sure"
+        }>)
+      end
+
+      assert {:ok, "not quite sure"} = Client.rect(element)
+    end
+  end
+
+  describe "take_screenshot/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      screenshot_data = ":)"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/screenshot"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{Base.encode64(screenshot_data)}"
+        }>)
+      end
+
+      assert ^screenshot_data = Client.take_screenshot(session)
+    end
+  end
+
+  describe "cookies/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/cookie"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": [{"domain": "localhost"}]
+        }>)
+      end
+
+      assert {:ok, [%{"domain" => "localhost"}]} = Client.cookies(session)
+    end
+  end
+
+  describe "set_cookie/3" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      key = "tester"
+      value = "McTestington"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/cookie"
+        assert conn.body_params == %{"cookie" => %{"name" => key, "value" => value}}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": []
+        }>)
+      end
+
+      assert {:ok, []} = Client.set_cookie(session, key, value)
+    end
+  end
+
+  describe "set_window_size/3" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+      height = 600
+      width = 400
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
+        assert conn.body_params == %{"height" => height, "width" => width}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.set_window_size(session, window_handle_id, width, height)
+    end
+  end
+
+  describe "get_window_size/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {
+            "height": 600,
+            "width": 400
+          }
+        }>)
+      end
+
+      assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session, window_handle_id)
+    end
+  end
+
+  describe "execute_script/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/execute"
+        assert conn.body_params == %{
+        "script" => "localStorage.clear()",
+        "args" => [2, "a"]}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, nil} = Client.execute_script(session, "localStorage.clear()", [2, "a"])
+    end
+  end
+
+  describe "send_keys/2" do
+    test "with a Session", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      keys = ["abc", :tab]
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/keys"
+        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Poison.decode!
+
+        resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, nil} = Client.send_keys(session, keys)
+    end
+
+    test "with an Element", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+      keys = ["abc", :tab]
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/value"
+        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Poison.decode!
+
+        resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": null
+        }>)
+      end
+
+      assert {:ok, nil} = Client.send_keys(element, keys)
+    end
+  end
+
+  describe "log/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/log"
+        assert conn.body_params == %{"type" => "browser"}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": []
+        }>)
+      end
+
+      assert {:ok, []} = Client.log(session)
+    end
+  end
+
+  describe "page_source/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      page_source = "<html></html>"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/source"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "#{page_source}"
+        }>)
+      end
+
+      assert {:ok, ^page_source} = Client.page_source(session)
+    end
+  end
+
+  describe "window_handle/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window_handle"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": "my-window-handle"
+        }>)
+      end
+
+      assert "my-window-handle" = Client.window_handle(session)
+    end
+  end
+
+  defp handle_request(bypass, handler_fn) do
+    Bypass.expect bypass, fn conn ->
+      conn |> parse_body |> handler_fn.()
+    end
+  end
+
+  defp build_session_for_bypass(bypass, session_id \\ "my-sample-session") do
+    session_url = bypass_url(bypass, "/session/#{session_id}")
+
+    %Session{id: session_id, session_url: session_url, url: session_url}
+  end
+
+  defp build_element_for_session(session, element_id \\ ":wdc:abc123") do
+    %Element{
+      id: element_id,
+      parent: session,
+      session_url: session.url,
+      url: "#{session.url}/element/#{element_id}",
+    }
+  end
+end


### PR DESCRIPTION
This isolates all of our HTTP interactions, and serializations/deserializations into a single module. This will make it easier to test and globally parse errors that come back from the webdriver API. I left the http tests on Wallaby.Phantom.Driver for the time being to make sure as I do further refactorings, I don't break anything.