### PR TITLE
Don't parse JSON on 204 status codes

### DIFF
--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -18,7 +18,6 @@ defmodule Wallaby.Phantom.Driver do
     {:error, :invalid_selector} |
     {:error, :stale_reference_error}
 
-
   @spec create(pid, Keyword.t) :: {:ok, Session.t}
   def create(server, opts) do
     base_url = Wallaby.Phantom.Server.get_base_url(server)

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -256,7 +256,22 @@ defmodule Wallaby.Phantom.DriverTest do
         end
       end
 
-      assert {:ok, %{}} = Driver.visit(session, url)
+      assert :ok = Driver.visit(session, url)
+    end
+
+    test "when browser sends back a 204 response", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      url = "http://www.google.com"
+
+      stub_backend bypass, session, fn conn ->
+        if conn.method == "POST" && conn.request_path == "/session/#{session.id}/url" do
+          assert conn.body_params == %{"url" => url}
+
+          send_resp(conn, 204, "")
+        end
+      end
+
+      assert :ok = Driver.visit(session, url)
     end
   end
 


### PR DESCRIPTION
I have seen this issue with BrowserStack returning 204 status codes when calling the /visit command on their Android 4.0 and 4.1 browsers. This change prevents wallaby from crashing because there is no JSON to parse on a 204 status code.