### PR TITLE
Move current driver into Wallaby.Session

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -988,13 +988,13 @@ defmodule Wallaby.Browser do
     session
   end
 
-  def cookies(%Session{driver: driver}=session) do
+  def cookies(%Session{driver: driver} = session) do
     {:ok, cookies_list} = driver.cookies(session)
 
     cookies_list
   end
 
-  def set_cookie(%Session{driver: driver}=session, key, value) do
+  def set_cookie(%Session{driver: driver} = session, key, value) do
     if blank_page?(session) do
       raise Wallaby.CookieException
     end
@@ -1014,7 +1014,7 @@ defmodule Wallaby.Browser do
   @doc """
   Accepts all subsequent JavaScript dialogs in the given session.
   """
-  def accept_dialogs(%Session{driver: driver}=session) do
+  def accept_dialogs(%Session{driver: driver} = session) do
     driver.accept_dialogs(session)
     session
   end
@@ -1022,7 +1022,7 @@ defmodule Wallaby.Browser do
   @doc """
   Dismisses all subsequent JavaScript dialogs in the given session.
   """
-  def dismiss_dialogs(%Session{driver: driver}=session) do
+  def dismiss_dialogs(%Session{driver: driver} = session) do
     driver.dismiss_dialogs(session)
     session
   end
@@ -1037,7 +1037,7 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def accept_alert(%Session{driver: driver}=session, fun) do
+  def accept_alert(%Session{driver: driver} = session, fun) do
     driver.accept_alert(session, fun)
   end
 
@@ -1051,7 +1051,7 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def accept_confirm(%Session{driver: driver}=session, fun) do
+  def accept_confirm(%Session{driver: driver} = session, fun) do
     driver.accept_confirm(session, fun)
   end
 
@@ -1066,7 +1066,7 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def dismiss_confirm(%Session{driver: driver}=session, fun) do
+  def dismiss_confirm(%Session{driver: driver} = session, fun) do
     driver.dismiss_confirm(session, fun)
   end
 
@@ -1091,15 +1091,15 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def accept_prompt(%Session{}=session, fun) do
+  def accept_prompt(%Session{} = session, fun) do
     do_accept_prompt(session, nil, fun)
   end
 
-  def accept_prompt(%Session{}=session, [with: input_value], fun) when is_binary(input_value) do
+  def accept_prompt(%Session{} = session, [with: input_value], fun) when is_binary(input_value) do
     do_accept_prompt(session, input_value, fun)
   end
 
-  defp do_accept_prompt(%Session{driver: driver}=session, input_value, fun) do
+  defp do_accept_prompt(%Session{driver: driver} = session, input_value, fun) do
     driver.accept_prompt(session, input_value, fun)
   end
 
@@ -1113,7 +1113,7 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def dismiss_prompt(%Session{driver: driver}=session, fun) do
+  def dismiss_prompt(%Session{driver: driver} = session, fun) do
     driver.dismiss_prompt(session, fun)
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -104,7 +104,6 @@ defmodule Wallaby.Browser do
   """
 
   alias Wallaby.Element
-  alias Wallaby.Phantom.Driver
   alias Wallaby.Query
   alias Wallaby.Query.ErrorMessage
   alias Wallaby.Session
@@ -411,10 +410,10 @@ defmodule Wallaby.Browser do
   """
   @spec take_screenshot(parent) :: parent
 
-  def take_screenshot(screenshotable) do
+  def take_screenshot(%{driver: driver} = screenshotable) do
     image_data =
       screenshotable
-      |> Driver.take_screenshot
+      |> driver.take_screenshot
 
     path = path_for_screenshot()
     File.write! path, image_data
@@ -427,8 +426,8 @@ defmodule Wallaby.Browser do
   """
   @spec window_size(parent) :: %{String.t => pos_integer, String.t => pos_integer}
 
-  def window_size(session) do
-    {:ok, size} = Driver.get_window_size(session)
+  def window_size(%Session{driver: driver} = session) do
+    {:ok, size} = driver.get_window_size(session)
     size
   end
 
@@ -437,8 +436,8 @@ defmodule Wallaby.Browser do
   """
   @spec resize_window(parent, pos_integer, pos_integer) :: parent
 
-  def resize_window(session, width, height) do
-    {:ok, _} = Driver.set_window_size(session, width, height)
+  def resize_window(%Session{driver: driver} = session, width, height) do
+    {:ok, _} = driver.set_window_size(session, width, height)
     session
   end
 
@@ -453,8 +452,8 @@ defmodule Wallaby.Browser do
   """
   @spec current_url(parent) :: String.t
 
-  def current_url(parent) do
-    Driver.current_url!(parent)
+  def current_url(%Session{driver: driver} = session) do
+    driver.current_url!(session)
   end
 
   def get_current_url(parent) do
@@ -468,8 +467,8 @@ defmodule Wallaby.Browser do
   """
   @spec current_path(parent) :: String.t
 
-  def current_path(parent) do
-    Driver.current_path!(parent)
+  def current_path(%Session{driver: driver} = session) do
+    driver.current_path!(session)
   end
 
   @doc """
@@ -477,8 +476,8 @@ defmodule Wallaby.Browser do
   """
   @spec page_title(parent) :: String.t
 
-  def page_title(session) do
-    {:ok, title} = Driver.page_title(session)
+  def page_title(%Session{driver: driver} = session) do
+    {:ok, title} = driver.page_title(session)
     title
   end
 
@@ -504,10 +503,10 @@ defmodule Wallaby.Browser do
     execute_script(session, script, [], callback)
   end
 
-  def execute_script(session, script, arguments, callback) when is_list(arguments) and is_function(callback) do
-    {:ok, value} = Driver.execute_script(session, script, arguments)
+  def execute_script(%{driver: driver} = parent, script, arguments, callback) when is_list(arguments) and is_function(callback) do
+    {:ok, value} = driver.execute_script(parent, script, arguments)
     callback.(value)
-    session
+    parent
   end
 
   @doc """
@@ -540,8 +539,8 @@ defmodule Wallaby.Browser do
   def send_keys(parent, keys) when is_binary(keys) do
     send_keys(parent, [keys])
   end
-  def send_keys(parent, keys) when is_list(keys) do
-    {:ok, _} = Driver.send_keys(parent, keys)
+  def send_keys(%{driver: driver} = parent, keys) when is_list(keys) do
+    {:ok, _} = driver.send_keys(parent, keys)
     parent
   end
 
@@ -561,8 +560,8 @@ defmodule Wallaby.Browser do
   """
   @spec page_source(parent) :: String.t
 
-  def page_source(session) do
-    {:ok, source} = Driver.page_source(session)
+  def page_source(%Session{driver: driver} = session) do
+    {:ok, source} = driver.page_source(session)
     source
   end
 
@@ -972,39 +971,39 @@ defmodule Wallaby.Browser do
   Relative paths are appended to the provided base_url.
   Absolute paths do not use the base_url.
   """
-  @spec visit(parent, String.t) :: session
+  @spec visit(session, String.t) :: session
 
-  def visit(session, path) do
+  def visit(%Session{driver: driver} = session, path) do
     uri = URI.parse(path)
 
     cond do
       uri.host == nil && String.length(base_url()) == 0 ->
         raise Wallaby.NoBaseUrl, path
       uri.host ->
-        Driver.visit(session, path)
+        driver.visit(session, path)
       true ->
-        Driver.visit(session, request_url(path))
+        driver.visit(session, request_url(path))
     end
 
     session
   end
 
-  def cookies(%Session{}=session) do
-    {:ok, cookies_list} = Driver.cookies(session)
+  def cookies(%Session{driver: driver}=session) do
+    {:ok, cookies_list} = driver.cookies(session)
 
     cookies_list
   end
 
-  def set_cookie(%Session{}=session, key, value) do
+  def set_cookie(%Session{driver: driver}=session, key, value) do
     if blank_page?(session) do
       raise Wallaby.CookieException
     end
 
-    case Driver.set_cookies(session, key, value) do
+    case driver.set_cookies(session, key, value) do
       {:ok, _list} ->
-      	session
+        session
       {:error, :invalid_cookie_domain} ->
-      	raise Wallaby.CookieException
+        raise Wallaby.CookieException
     end
   end
 
@@ -1015,16 +1014,16 @@ defmodule Wallaby.Browser do
   @doc """
   Accepts all subsequent JavaScript dialogs in the given session.
   """
-  def accept_dialogs(%Session{}=session) do
-    Driver.accept_dialogs(session)
+  def accept_dialogs(%Session{driver: driver}=session) do
+    driver.accept_dialogs(session)
     session
   end
 
   @doc """
   Dismisses all subsequent JavaScript dialogs in the given session.
   """
-  def dismiss_dialogs(%Session{}=session) do
-    Driver.dismiss_dialogs(session)
+  def dismiss_dialogs(%Session{driver: driver}=session) do
+    driver.dismiss_dialogs(session)
     session
   end
 
@@ -1038,8 +1037,8 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def accept_alert(%Session{}=session, fun) do
-    Driver.accept_alert(session, fun)
+  def accept_alert(%Session{driver: driver}=session, fun) do
+    driver.accept_alert(session, fun)
   end
 
   @doc """
@@ -1052,8 +1051,8 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def accept_confirm(%Session{}=session, fun) do
-    Driver.accept_confirm(session, fun)
+  def accept_confirm(%Session{driver: driver}=session, fun) do
+    driver.accept_confirm(session, fun)
   end
 
   @doc """
@@ -1067,8 +1066,8 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def dismiss_confirm(%Session{}=session, fun) do
-    Driver.dismiss_confirm(session, fun)
+  def dismiss_confirm(%Session{driver: driver}=session, fun) do
+    driver.dismiss_confirm(session, fun)
   end
 
   @doc """
@@ -1100,8 +1099,8 @@ defmodule Wallaby.Browser do
     do_accept_prompt(session, input_value, fun)
   end
 
-  defp do_accept_prompt(%Session{}=session, input_value, fun) do
-    Driver.accept_prompt(session, input_value, fun)
+  defp do_accept_prompt(%Session{driver: driver}=session, input_value, fun) do
+    driver.accept_prompt(session, input_value, fun)
   end
 
   @doc """
@@ -1114,8 +1113,8 @@ defmodule Wallaby.Browser do
   end
   ```
   """
-  def dismiss_prompt(%Session{}=session, fun) do
-    Driver.dismiss_prompt(session, fun)
+  def dismiss_prompt(%Session{driver: driver}=session, fun) do
+    driver.dismiss_prompt(session, fun)
   end
 
   defp validate_html(parent, %{html_validation: :button_type}=query) do
@@ -1172,8 +1171,8 @@ defmodule Wallaby.Browser do
     end
   end
 
-  defp matching_text?(element, text) do
-    case Driver.text(element) do
+  defp matching_text?(%Element{driver: driver} = element, text) do
+    case driver.text(element) do
       {:ok, element_text} ->
         element_text =~ ~r/#{Regex.escape(text)}/
       {:error, _} ->
@@ -1181,12 +1180,12 @@ defmodule Wallaby.Browser do
     end
   end
 
-  def execute_query(parent, query) do
+  def execute_query(%{driver: driver} = parent, query) do
     retry fn ->
       try do
         with {:ok, query}  <- Query.validate(query),
-             {method, selector} <- Query.compile(query),
-             {:ok, elements} <- Driver.find_elements(parent, {method, selector}),
+             compiled_query <- Query.compile(query),
+             {:ok, elements} <- driver.find_elements(parent, compiled_query),
              {:ok, elements} <- validate_visibility(query, elements),
              {:ok, elements} <- validate_text(query, elements),
              {:ok, elements} <- validate_count(query, elements),

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -1,0 +1,158 @@
+defmodule Wallaby.Driver do
+  @moduledoc false
+
+  alias Wallaby.{Element, Query, Session}
+
+  @type reason :: any
+  @type url :: String.t
+  @type open_dialog_fn :: ((Session.t) -> any)
+  @type window_dimension :: %{String.t => pos_integer, String.t => pos_integer}
+
+  @doc """
+  Invoked to start a browser session.
+  """
+  @callback start_session(Keyword.t) :: {:ok, Session.t} | {:error, reason}
+
+  @doc """
+  Invoked to stop a browser sesssion.
+  """
+  @callback end_session(Session.t) :: :ok | {:error, reason}
+
+  @doc """
+  Invoked to accept one alert triggered within `open_dialog_fn` and return the alert message.
+  """
+  @callback accept_alert(Session.t, open_dialog_fn) :: {:ok, [String.t]}
+
+  @doc """
+  Invoked to accept one confirm triggered within `open_dialog_fn` and return the confirm message.
+  """
+  @callback accept_confirm(Session.t, open_dialog_fn) :: {:ok, [String.t]}
+
+  @doc """
+  Invoked to accept all open dialogs.
+  """
+  @callback accept_dialogs(Session.t) :: {:ok, String.t}
+
+  @doc """
+  Invoked to accept one prompt triggered within `open_dialog_fn` and return the prompt message.
+  """
+  @callback accept_prompt(Session.t, String.t | nil, open_dialog_fn) :: {:ok, [String.t]}
+
+  @doc """
+  Invoked to retrieve cookies for the given session.
+  """
+  @callback cookies(Session.t) :: {:ok, [%{String.t => String.t}]} | {:error, reason}
+
+  @doc """
+  Invoked to get the current path of the browser's session.
+  """
+  @callback current_path!(Session.t) :: String.t | nil | no_return
+
+  @doc """
+  Invoked to get the current url of the browser's session.
+  """
+  @callback current_url!(Session.t) :: String.t | nil | no_return
+
+  @doc """
+  Invoked to dismiss all open dialogs.
+  """
+  @callback dismiss_dialogs(Session.t) :: {:ok, String.t}
+
+  @doc """
+  Invoked to dismiss one confirm triggered within `open_dialog_fn` and return the confirm message.
+  """
+  @callback dismiss_confirm(Session.t, open_dialog_fn) :: {:ok, [String.t]}
+
+  @doc """
+  Invoked to dismiss one prompt triggered within `open_dialog_fn` and return the prompt message.
+  """
+  @callback dismiss_prompt(Session.t, open_dialog_fn) :: {:ok, [String.t]}
+
+  @doc """
+  Invoked to retrieve the size of the window.
+  """
+  @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the html source of the current page.
+  """
+  @callback page_source(Session.t) :: {:ok, String.t} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the title of the current page.
+  """
+  @callback page_title(Session.t) :: {:ok, String.t} | {:error, reason}
+
+  @doc """
+  Invoked to set a cookie on a session
+  """
+  @callback set_cookies(Session.t, String.t, String.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to set the size of the window.
+  """
+  @callback set_window_size(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to visit a url.
+  """
+  @callback visit(Session.t, url) :: :ok | {:error, reason}
+
+  @doc """
+  Invoked to return the value of an element's attribute.
+  """
+  @callback attribute(Element.t, String.t) :: {:ok, String.t | nil} |
+    {:error, reason}
+
+  @doc """
+  Invoked to clear an element.
+  """
+  @callback clear(Element.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to click on an element.
+  """
+  @callback click(Element.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to check if an element is currently visible.
+  """
+  @callback displayed(Element.t) :: {:ok, boolean} | {:error, reason}
+
+  @doc """
+  Invoked to check if an element is selected (like a checkbox).
+  """
+  @callback selected(Element.t) :: {:ok, boolean} | {:error, reason}
+
+  @doc """
+  Invoked to set the value of the given element.
+  """
+  @callback set_value(Element.t, any) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to return the text from the element.
+  """
+  @callback text(Element.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to find child elements of the given session/element.
+  """
+  @callback find_elements(Session.t | Element.t, Query.compiled) ::
+    {:ok, [Element.t]} | {:error, reason}
+
+  @doc """
+  Invoked to execute javascript in the browser.
+  """
+  @callback execute_script(Session.t | Element, String.t, [any]) ::
+    {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to send keys to the browser.
+  """
+  @callback send_keys(Session.t | Element.t, String.t | [String.t | atom]) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to take a screenshot of the session/element.
+  """
+  @callback take_screenshot(Session.t | Element.t) :: binary
+end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -25,9 +25,7 @@ defmodule Wallaby.Element do
   Unlike `Browser` the actions in `Element` do not retry if the element becomes stale. Instead an exception will be raised.
   """
 
-  alias Wallaby.Phantom.Driver
-
-  defstruct [:url, :session_url, :parent, :id, screenshots: []]
+  defstruct [:url, :session_url, :parent, :id, :driver, screenshots: []]
 
   @opaque value :: String.t | number()
 
@@ -38,6 +36,7 @@ defmodule Wallaby.Element do
     url: String.t,
     id: String.t,
     screenshots: list,
+    driver: module,
   }
 
   @doc """
@@ -45,12 +44,12 @@ defmodule Wallaby.Element do
   """
   @spec clear(t) :: t
 
-  def clear(element) do
-    case Driver.clear(element) do
+  def clear(%__MODULE__{driver: driver} = element) do
+    case driver.clear(element) do
       {:ok, _} ->
-	element
+        element
       {:error, _} ->
-	raise Wallaby.StaleReferenceException
+        raise Wallaby.StaleReferenceException
     end
   end
 
@@ -73,12 +72,12 @@ defmodule Wallaby.Element do
   """
   @spec click(t) :: t
 
-  def click(element) do
-    case Driver.click(element) do
+  def click(%__MODULE__{driver: driver} = element) do
+    case driver.click(element) do
       {:ok, _} ->
-      	element
+        element
       {:error, _} ->
-      	raise Wallaby.StaleReferenceException
+        raise Wallaby.StaleReferenceException
     end
   end
 
@@ -87,8 +86,8 @@ defmodule Wallaby.Element do
   """
   @spec text(t) :: String.t
 
-  def text(element) do
-    case Driver.text(element) do
+  def text(%__MODULE__{driver: driver} = element) do
+    case driver.text(element) do
       {:ok, text} ->
         text
       {:error, :stale_reference_error} ->
@@ -101,12 +100,12 @@ defmodule Wallaby.Element do
   """
   @spec attr(t, attr()) :: String.t | nil
 
-  def attr(element, name) do
-    case Driver.attribute(element, name) do
+  def attr(%__MODULE__{driver: driver} = element, name) do
+    case driver.attribute(element, name) do
       {:ok, attribute} ->
-	attribute
+        attribute
       {:error, _} ->
-	raise Wallaby.StaleReferenceException
+        raise Wallaby.StaleReferenceException
     end
   end
 
@@ -114,14 +113,14 @@ defmodule Wallaby.Element do
   Returns a boolean based on whether or not the element is selected.
 
   ## Note
-  This only really makes sense for options, checkboxes, and radi buttons.
+  This only really makes sense for options, checkboxes, and radio buttons.
   Everything else will simply return false because they have no notion of
   "selected".
   """
   @spec selected?(t) :: boolean()
 
-  def selected?(element) do
-    case Driver.selected(element) do
+  def selected?(%__MODULE__{driver: driver} = element) do
+    case driver.selected(element) do
       {:ok, value} ->
         value
       {:error, _} ->
@@ -134,12 +133,12 @@ defmodule Wallaby.Element do
   """
   @spec visible?(t) :: boolean()
 
-  def visible?(element) do
-    case Driver.displayed(element) do
+  def visible?(%__MODULE__{driver: driver} = element) do
+    case driver.displayed(element) do
       {:ok, value} ->
-	value
+        value
       {:error, _} ->
-	false
+        false
     end
   end
 
@@ -148,12 +147,12 @@ defmodule Wallaby.Element do
   """
   @spec set_value(t, value()) :: t
 
-  def set_value(element, value) do
-    case Driver.set_value(element, value) do
+  def set_value(%__MODULE__{driver: driver} = element, value) do
+    case driver.set_value(element, value) do
       {:ok, _} ->
-	element
+        element
       {:error, :stale_reference_error} ->
-	raise Wallaby.StaleReferenceException
+        raise Wallaby.StaleReferenceException
     end
   end
 
@@ -165,12 +164,12 @@ defmodule Wallaby.Element do
   def send_keys(element, text) when is_binary(text) do
     send_keys(element, [text])
   end
-  def send_keys(element, keys) when is_list(keys) do
-    case Driver.send_keys(element, keys) do
+  def send_keys(%__MODULE{driver: driver} = element, keys) when is_list(keys) do
+    case driver.send_keys(element, keys) do
       {:ok, _} ->
-	element
+        element
       {:error, :stale_reference_error} ->
-	raise Wallaby.StaleReferenceException
+        raise Wallaby.StaleReferenceException
     end
   end
 

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -3,6 +3,8 @@ defmodule Wallaby.Phantom do
 
   alias Wallaby.Phantom.Driver
 
+  @behaviour Wallaby.Driver
+
   @moduledoc false
   @pool_name Wallaby.ServerPool
 
@@ -49,6 +51,36 @@ defmodule Wallaby.Phantom do
     Driver.delete(session)
     :poolboy.checkin(Wallaby.ServerPool, server)
   end
+
+  defdelegate accept_dialogs(session),                            to: Driver
+  defdelegate accept_alert(session, open_dialog_fn),              to: Driver
+  defdelegate accept_confirm(session, open_dialog_fn),            to: Driver
+  defdelegate accept_prompt(session, input_va, open_dialog_fn),   to: Driver
+  defdelegate cookies(session),                                   to: Driver
+  defdelegate current_path!(session),                             to: Driver
+  defdelegate current_url!(session),                              to: Driver
+  defdelegate dismiss_dialogs(session),                           to: Driver
+  defdelegate dismiss_confirm(session, open_dialog_fn),           to: Driver
+  defdelegate dismiss_prompt(session, open_dialog_fn),            to: Driver
+  defdelegate get_window_size(session),                           to: Driver
+  defdelegate page_title(session),                                to: Driver
+  defdelegate page_source(session),                               to: Driver
+  defdelegate set_cookies(session, key, value),                   to: Driver
+  defdelegate set_window_size(session, width, height),            to: Driver
+  defdelegate visit(session, url),                                to: Driver
+
+  defdelegate attribute(element, name),                           to: Driver
+  defdelegate click(element),                                     to: Driver
+  defdelegate clear(element),                                     to: Driver
+  defdelegate displayed(element),                                 to: Driver
+  defdelegate selected(element),                                  to: Driver
+  defdelegate set_value(element, value),                          to: Driver
+  defdelegate text(element),                                      to: Driver
+
+  defdelegate execute_script(session_or_element, script, args),   to: Driver
+  defdelegate find_elements(session_or_element, compiled_query),  to: Driver
+  defdelegate send_keys(session_or_element, keys),                to: Driver
+  defdelegate take_screenshot(session_or_element),                to: Driver
 
   def user_agent do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -37,7 +37,8 @@ defmodule Wallaby.Phantom.Driver do
       session_url: base_url <> "session/#{id}",
       url: base_url <> "session/#{id}",
       id: id,
-      server: server
+      server: server,
+      driver: Wallaby.Phantom
     }
 
     {:ok, session}
@@ -573,6 +574,7 @@ defmodule Wallaby.Phantom.Driver do
       session_url: parent.session_url,
       url: parent.session_url <> "/element/#{id}",
       parent: parent,
+      driver: parent.driver,
     }
   end
 

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -94,6 +94,8 @@ defmodule Wallaby.Query do
     result: result(),
   }
 
+  @type compiled :: {:xpath | :css, String.t}
+
 
   def css(selector, opts \\ []) do
     %Query{
@@ -212,6 +214,7 @@ defmodule Wallaby.Query do
     end
   end
 
+  @spec compile(t) :: compiled
   def compile(%{method: :css, selector: selector}), do: {:css, selector}
   def compile(%{method: :xpath, selector: selector}), do: {:xpath, selector}
   def compile(%{method: :link, selector: selector}), do: {:xpath, XPath.link(selector)}

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -45,10 +45,11 @@ defmodule Wallaby.Session do
     session_url: String.t,
     url: String.t,
     server: pid(),
-    screenshots: list
+    screenshots: list,
+    driver: module
   }
 
-  defstruct [:id, :url, :session_url, :server, screenshots: []]
+  defstruct [:id, :url, :session_url, :server, :driver, screenshots: []]
 
   def set_window_size(parent, x, y) do
     IO.warn "set_window_size/3 has been deprecated. Please use Browser.resize_window/3"


### PR DESCRIPTION
This moves the responsibility for determining the Wallaby driver to use to the Session and removes all of the hard-coded references to `Wallaby.Phantom.Driver`.

I also created a `Wallaby.Driver` behavior which new drivers will need to implement. I left this behavior with `@moduledoc false` in case we wanted to adjust the interface before making it public. Also, I'm thinking the ideal api for `Wallaby.start_session/1` will be:

```elixir
Wallaby.start_session(driver: Wallaby.Selenium, remote_url: "http://...")
```
instead of 
```elixir
Wallaby.start_session(driver: Wallaby.Selenium.Driver, remote_url: "http://...")
```
which is why I've delegated all of those functions in `Wallaby.Phantom`.