### PR TITLE
Fixes typespec for Browser.visit/2

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -972,7 +972,7 @@ defmodule Wallaby.Browser do
   Relative paths are appended to the provided base_url.
   Absolute paths do not use the base_url.
   """
-  @spec visit(parent, String.t) :: Session.t
+  @spec visit(parent, String.t) :: session
 
   def visit(session, path) do
     uri = URI.parse(path)


### PR DESCRIPTION
Since browser uses opaque types, dialyzer was giving me the following error with this code: `session |> visit("http://example.com") |> find(Query.css("#my-id"))`

```
lib/trusted_form_smoke_tester/integration_tests/trusted_form_page.ex:60: The call 'Elixir.Wallaby.Browser':find(session@1::#{'__struct__':='Elixir.Wallaby.Session', 'driver':=atom(), 'id':=binary(), 'screenshots':=[any()], 'server':='nil' | pid(), 'session_url':=binary(), 'url':=binary()},#{'__struct__':='Elixir.Wallaby.Query', 'conditions':=[{atom(),_}], 'html_validation':='nil', 'method':='css', 'result':=[], 'selector':=_}) does not have an opaque term of type 'Elixir.Wallaby.Browser':element() | 'Elixir.Wallaby.Browser':session() as 1st argument
```

This switches `Browser.visit/2` to return the opaque type.