### PR TITLE
Allow adjusting hackney options

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,25 @@ Application.put_env(:wallaby, :js_logger, file)
 
 Logging can be disabled by setting `:js_logger` to `nil`.
 
+## Config
+
+### Adjusting timeouts
+
+Wallaby uses [hackney](https://github.com/benoitc/hackney) under the hood, so we
+offer a hook that allows you to control any hackney options you'd like to have
+sent along on every request. This can be controlled with the `:hackney_options`
+setting in `config.exs`.
+
+```elixir
+# default values
+config :wallaby,
+  hackney_options: [timeout: :infinity, recv_timeout: :infinity]
+
+# Overriding a value
+config :wallaby,
+  hackney_options: [timeout: 5_000]
+```
+
 ## Contributing
 
 Wallaby is a community project. PRs and Issues are greatly welcome.

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,8 @@ config :wallaby,
   pool_size: 3,
   js_logger: :stdio,
   screenshot_on_failure: false,
-  js_errors: true
+  js_errors: true,
+  hackney_options: [timeout: :infinity, recv_timeout: :infinity]
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -560,7 +560,7 @@ defmodule Wallaby.Phantom.Driver do
   end
 
   def request_opts do
-    [timeout: :infinity, recv_timeout: :infinity]
+    Application.get_env(:wallaby, :hackney_options, [])
   end
 
   def headers do


### PR DESCRIPTION
I was having an issue where BrowserStack wasn't sending me a response on some of my commands, causing my script to just hang. This change will allow me to override the hackney options and set custom timeouts.