### PR TITLE
Only document modules for public API

### DIFF
--- a/integration_test/support/test_server.ex
+++ b/integration_test/support/test_server.ex
@@ -1,4 +1,6 @@
 defmodule Wallaby.Integration.TestServer do
+  @moduledoc false
+
   @config [ port: 0,
             server_root:   String.to_char_list(Path.absname("./", __DIR__)),
             document_root: String.to_char_list(Path.absname("./pages", __DIR__)),

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -19,6 +19,7 @@ defmodule Wallaby do
 
   alias Wallaby.Session
 
+  @doc false
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
@@ -36,7 +37,35 @@ defmodule Wallaby do
     {atom, any}
 
   @doc """
-  Starts a browser session
+  Starts a browser session.
+
+  ## Multiple sessions
+
+  Each session runs in its own browser so that each test runs in isolation.
+  Because of this isolation multiple sessions can be created for a test:
+
+  ```
+  @message_field Query.text_field("Share Message")
+  @share_button Query.button("Share")
+  @message_list Query.css(".messages")
+
+  test "That multiple sessions work" do
+    {:ok, user1} = Wallaby.start_session
+    user1
+    |> visit("/page.html")
+    |> fill_in(@message_field, with: "Hello there!")
+    |> click(@share_button)
+
+    {:ok, user2} = Wallaby.start_session
+    user2
+    |> visit("/page.html")
+    |> fill_in(@message_field, with: "Hello yourself")
+    |> click(@share_button)
+
+    assert user1 |> find(@message_list) |> List.last |> text == "Hello yourself"
+    assert user2 |> find(@message_list) |> List.first |> text == "Hello there"
+  end
+  ```
   """
   @spec start_session([start_session_opts]) :: {:ok, Session.t} | {:error, reason}
   def start_session(opts \\ []) do
@@ -45,25 +74,29 @@ defmodule Wallaby do
   end
 
   @doc """
-  Ends a browser session
+  Ends a browser session.
   """
   @spec end_session(Session.t) :: {:ok, Session.t} | {:error, reason}
   def end_session(%Session{driver: driver} = session) do
     driver.end_session(session)
   end
 
+  @doc false
   def screenshot_on_failure? do
     Application.get_env(:wallaby, :screenshot_on_failure)
   end
 
+  @doc false
   def js_errors? do
     Application.get_env(:wallaby, :js_errors, true)
   end
 
+  @doc false
   def js_logger do
     Application.get_env(:wallaby, :js_logger, :stdio)
   end
 
+  @doc false
   def phantomjs_path do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end

--- a/lib/wallaby/dsl.ex
+++ b/lib/wallaby/dsl.ex
@@ -1,5 +1,30 @@
 defmodule Wallaby.DSL do
-  @moduledoc false
+  @moduledoc """
+  Sets up the Wallaby DSL in a module.
+
+  All functions in `Wallaby.Browser` are now accessible without a module name
+  and `Wallaby.Browser`, `Wallaby.Element` and `Wallaby.Query` are all aliased.
+
+  ## Example
+
+  ```
+  defmodule MyPage do
+    use Wallaby.DSL
+
+    @name_field Query.text_field("Name")
+    @email_field Query.text_field("email")
+    @save_button Query.button("Save")
+
+    def register(session) do
+      session
+      |> visit("/registration.html")
+      |> fill_in(@name_field, with: "Chris")
+      |> fill_in(@email_field, with: "c@keathly.io")
+      |> click(@save_button)
+    end
+  end
+  ```
+  """
 
   defmacro __using__([]) do
     quote do

--- a/lib/wallaby/helpers/key_codes.ex
+++ b/lib/wallaby/helpers/key_codes.ex
@@ -1,8 +1,8 @@
 defmodule Wallaby.Helpers.KeyCodes do
-  @moduledoc """
-  Helper utility for converting key atoms into key codes sutiable to send over
-  the wire.
-  """
+  @moduledoc false
+
+  # Helper utility for converting key atoms into key codes suitable to send over
+  # the wire.
 
   @doc """
   Encode a list of key codes to a usable json representation.

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -1,9 +1,10 @@
 defmodule Wallaby.Metadata do
-  @moduledoc """
-  Metadata is used to encode information about the browser and test. This
-  information is then stored in a User Agent string. The information from the
-  test can then be extracted in the application.
-  """
+  @moduledoc false
+
+  # Metadata is used to encode information about the browser and test. This
+  # information is then stored in a User Agent string. The information from the
+  # test can then be extracted in the application.
+
 
   @prefix "BeamMetadata"
   @regex ~r{#{@prefix} \((.*?)\)}

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -1,13 +1,45 @@
 defmodule Wallaby.Phantom do
+  @moduledoc """
+  Wallaby driver for PhantomJS.
+
+  ## Usage
+
+  Start a Wallaby Session using this driver with the following command:
+
+  ```
+  {:ok, session} = Wallaby.start_session(driver: Wallaby.Phantom)
+  ```
+
+  ## Notes
+
+  This driver requires PhantomJS be installed in your path. You can install PhantomJS through NPM or your package manager of choice:
+
+  ```
+  $ npm install -g phantomjs-prebuilt
+  ```
+
+  If you need to specify a specific PhantomJS you can pass the path in the configuration:
+
+  ```
+  config :wallaby, phantomjs: "node_modules/.bin/phantomjs"
+  ```
+
+  You can also pass arguments to PhantomJS through the `phantomjs_args` config setting, e.g.:
+
+  ```
+  config :wallaby, phantomjs_args: "--webdriver-logfile=phantomjs.log"
+  ```
+  """
+
   use Supervisor
 
   alias Wallaby.Phantom.Driver
 
   @behaviour Wallaby.Driver
 
-  @moduledoc false
   @pool_name Wallaby.ServerPool
 
+  @doc false
   def start_link(opts\\[]) do
     Supervisor.start_link(__MODULE__, :ok, opts)
   end
@@ -21,12 +53,14 @@ defmodule Wallaby.Phantom do
     supervise(children, strategy: :one_for_one)
   end
 
+  @doc false
   def capabilities(opts) do
     default_capabilities()
     |> Map.merge(user_agent_capability(opts[:user_agent]))
     |> Map.merge(custom_headers_capability(opts[:custom_headers]))
   end
 
+  @doc false
   def default_capabilities do
     %{
       javascriptEnabled: true,
@@ -41,56 +75,88 @@ defmodule Wallaby.Phantom do
     }
   end
 
+  @doc false
   def start_session(opts) do
     server = :poolboy.checkout(@pool_name, true, :infinity)
     Wallaby.Phantom.Driver.create(server, opts)
   end
 
+  @doc false
   def end_session(%Wallaby.Session{server: server}=session) do
     Driver.execute_script(session, "localStorage.clear()")
     Driver.delete(session)
     :poolboy.checkin(Wallaby.ServerPool, server)
   end
 
+  @doc false
   defdelegate accept_dialogs(session),                            to: Driver
+  @doc false
   defdelegate accept_alert(session, open_dialog_fn),              to: Driver
+  @doc false
   defdelegate accept_confirm(session, open_dialog_fn),            to: Driver
+  @doc false
   defdelegate accept_prompt(session, input_va, open_dialog_fn),   to: Driver
+  @doc false
   defdelegate cookies(session),                                   to: Driver
+  @doc false
   defdelegate current_path!(session),                             to: Driver
+  @doc false
   defdelegate current_url!(session),                              to: Driver
+  @doc false
   defdelegate dismiss_dialogs(session),                           to: Driver
+  @doc false
   defdelegate dismiss_confirm(session, open_dialog_fn),           to: Driver
+  @doc false
   defdelegate dismiss_prompt(session, open_dialog_fn),            to: Driver
+  @doc false
   defdelegate get_window_size(session),                           to: Driver
+  @doc false
   defdelegate page_title(session),                                to: Driver
+  @doc false
   defdelegate page_source(session),                               to: Driver
+  @doc false
   defdelegate set_cookies(session, key, value),                   to: Driver
+  @doc false
   defdelegate set_window_size(session, width, height),            to: Driver
+  @doc false
   defdelegate visit(session, url),                                to: Driver
 
+  @doc false
   defdelegate attribute(element, name),                           to: Driver
+  @doc false
   defdelegate click(element),                                     to: Driver
+  @doc false
   defdelegate clear(element),                                     to: Driver
+  @doc false
   defdelegate displayed(element),                                 to: Driver
+  @doc false
   defdelegate selected(element),                                  to: Driver
+  @doc false
   defdelegate set_value(element, value),                          to: Driver
+  @doc false
   defdelegate text(element),                                      to: Driver
 
+  @doc false
   defdelegate execute_script(session_or_element, script, args),   to: Driver
+  @doc false
   defdelegate find_elements(session_or_element, compiled_query),  to: Driver
+  @doc false
   defdelegate send_keys(session_or_element, keys),                to: Driver
+  @doc false
   defdelegate take_screenshot(session_or_element),                to: Driver
 
+  @doc false
   def user_agent do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
   end
 
+  @doc false
   def user_agent_capability(nil), do: %{}
   def user_agent_capability(ua) do
     %{"phantomjs.page.settings.userAgent" => ua}
   end
 
+  @doc false
   def custom_headers_capability(nil), do: %{}
   def custom_headers_capability(ch) do
     Enum.reduce(ch, %{}, fn ({k, v}, acc) ->
@@ -98,6 +164,7 @@ defmodule Wallaby.Phantom do
     end)
   end
 
+  @doc false
   def pool_size do
     Application.get_env(:wallaby, :pool_size) || default_pool_size()
   end

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -1,7 +1,5 @@
 defmodule Wallaby.Phantom.Driver do
-  @moduledoc ~S"""
-  Implements the webdriver protocol for Phantomjs
-  """
+  @moduledoc false
 
   alias Wallaby.Session
   alias Wallaby.Element

--- a/lib/wallaby/phantom/log_store.ex
+++ b/lib/wallaby/phantom/log_store.ex
@@ -1,4 +1,6 @@
 defmodule Wallaby.Phantom.LogStore do
+  @moduledoc false
+
   def start_link do
     Agent.start_link(fn -> Map.new end, name: __MODULE__)
   end

--- a/lib/wallaby/phantom/logger.ex
+++ b/lib/wallaby/phantom/logger.ex
@@ -1,4 +1,5 @@
 defmodule Wallaby.Phantom.Logger do
+  @moduledoc false
   @line_number_regex ~r/\s\((undefined)?:(undefined)?\)$/
 
   def log(logs) when is_list(logs) do

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -1,4 +1,5 @@
 defmodule Wallaby.Phantom.Server do
+  @moduledoc false
   use GenServer
 
   @external_resource "priv/run_phantom.sh"

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -1,4 +1,6 @@
 defmodule Wallaby.Query.ErrorMessage do
+  @moduledoc false
+
   alias Wallaby.Query
 
   @doc """

--- a/lib/wallaby/query/xpath.ex
+++ b/lib/wallaby/query/xpath.ex
@@ -1,4 +1,6 @@
 defmodule Wallaby.Query.XPath do
+  @moduledoc false
+
   @type query :: String.t
   @type xpath :: String.t
   @type name  :: query

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -1,44 +1,5 @@
 defmodule Wallaby.Session do
-  @moduledoc """
-  Common functionality for interacting with Sessions.
-
-  Sessions are used to represent a user navigating through and interacting with
-  different pages.
-
-  ## Fields
-
-  * `id` - The session id generated from the webdriver
-  * `session_url` - The base url for the application under test.
-  * `server` - The specific webdriver server that the session is running in.
-
-  ## Multiple sessions
-
-  Each session runs in its own browser so that each test runs in isolation.
-  Because of this isolation multiple sessions can be created for a test:
-
-  ```
-  @message_field Query.text_field("Share Message")
-  @share_button Query.button("Share")
-  @message_list Query.css(".messages")
-
-  test "That multiple sessions work" do
-    {:ok, user1} = Wallaby.start_session
-    user1
-    |> visit("/page.html")
-    |> fill_in(@message_field, with: "Hello there!")
-    |> click(@share_button)
-
-    {:ok, user2} = Wallaby.start_session
-    user2
-    |> visit("/page.html")
-    |> fill_in(@message_field, with: "Hello yourself")
-    |> click(@share_button)
-
-    assert user1 |> find(@message_list) |> List.last |> text == "Hello yourself"
-    assert user2 |> find(@message_list) |> List.first |> text == "Hello there"
-  end
-  ```
-  """
+  @moduledoc false
 
   @type t :: %__MODULE__{
     id: String.t,


### PR DESCRIPTION
This removes quite a few modules from the API docs that aren't meant for public usage. This will allow us to know exactly what functions people depend on and which ones we need to consider backward compatibility on. Here's what the API docs look like now.

![screen shot 2017-04-26 at 1 59 30 pm](https://cloud.githubusercontent.com/assets/120878/25454945/4bc5f212-2a8b-11e7-9e6d-657bed4eec79.png)

There's still quite a few of deprecated functions in `Wallaby.Browser` that need to be removed, but I figured they will be taken care of as part of #177.