### PR TITLE
Run against Erlang 19.3 & 18.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.4.2
-erlang 19.1
+erlang 19.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,8 @@ before_script:
 
 script:
   - mix test
-  - "if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi"
-
-matrix:
-  exclude:
-    - elixir: 1.4.2
-      otp_release: 18.2.1
-    - elixir: 1.3.4
-      otp_release: 19.2
+  # skip dialyzer for elixir 1.4 and erlang 18 as it produces weird errors, see #69
+  - "if [ -z ${WALLABY_DRIVER} ] && ! ([[ "$TRAVIS_ELIXIR_VERSION" == "1.4"* ]] && [[ "$TRAVIS_OTP_RELEASE" == "18"* ]]); then mix dialyzer --halt-exit-status; fi"
 
 env:
   - ""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
-elixir:
+elixir: 
   - 1.4.2
   - 1.3.4
 otp_release:
- - 19.2
- - 18.2.1
+  - 19.3
+  - 18.3
 # Run in bigger container so we don't run out of memory generating the plt
 sudo: required
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   directories:
     - _build
     - deps
+
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
   - "if [ -z ${WALLABY_DRIVER} ]; then travis_wait mix dialyzer --plt; fi"
@@ -18,8 +19,8 @@ before_script:
 
 script:
   - mix test
-  # skip dialyzer for elixir 1.4 and erlang 18 as it produces weird errors, see #69
-  - "if [ -z ${WALLABY_DRIVER} ] && ! ([[ "$TRAVIS_ELIXIR_VERSION" == "1.4"* ]] && [[ "$TRAVIS_OTP_RELEASE" == "18"* ]]); then mix dialyzer --halt-exit-status; fi"
+  - # skip dialyzer for elixir 1.4 and erlang 18 as it produces weird errors, see #69
+  - if [ -z ${WALLABY_DRIVER} ] && ! ([[ "$TRAVIS_ELIXIR_VERSION" == "1.4"* ]] && [[ "$TRAVIS_OTP_RELEASE" == "18"* ]]); then mix dialyzer --halt-exit-status; fi
 
 env:
   - ""


### PR DESCRIPTION
* also found out there is an erlang 18.3.4 which we can run against
* made it a proper crossover matrix with all elixir versions against
  all erlang versions - thank you travis sorry for the load :)