### PR TITLE
Automatically clean up sessions created with start_test_session/1

### DIFF
--- a/integration_test/cases/browser/local_storage_test.exs
+++ b/integration_test/cases/browser/local_storage_test.exs
@@ -7,6 +7,7 @@ defmodule Wallaby.Integration.Browser.LocalStorageTest do
   @get_value_script "return localStorage.getItem('test')"
   @set_value_script "localStorage.setItem('test', 'foo')"
 
+  @tag :skip_test_session
   test "local storage is not shared between sessions" do
     # Checkout all sessions
     {:ok, session}  = start_test_session()

--- a/integration_test/cases/wallaby_test.exs
+++ b/integration_test/cases/wallaby_test.exs
@@ -1,0 +1,15 @@
+defmodule Wallaby.Integration.WallabyTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  describe "end_session/2" do
+    test "calling end_session on an active session", %{session: session} do
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "calling end_session on an already closed session", %{session: session} do
+      Wallaby.end_session(session)
+
+      assert :ok = Wallaby.end_session(session)
+    end
+  end
+end

--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -8,15 +8,7 @@ defmodule Wallaby.Integration.SessionCase do
     end
   end
 
-  setup do
-    {:ok, session} = start_test_session()
-
-    on_exit fn ->
-      Wallaby.end_session(session)
-    end
-
-    {:ok, %{session: session}}
-  end
+  setup :inject_test_session
 
   @doc """
   Starts a test session with the default opts for the given driver
@@ -27,7 +19,19 @@ defmodule Wallaby.Integration.SessionCase do
       |> default_opts_for_driver
       |> Keyword.merge(opts)
 
-    Wallaby.start_session(session_opts)
+    with {:ok, session} <- Wallaby.start_session(session_opts),
+        :ok <- on_exit(fn -> Wallaby.end_session(session) end),
+        do: {:ok, session}
+  end
+
+  @doc """
+  Injects a test session into the test context
+  """
+  def inject_test_session(%{skip_test_session: true}), do: :ok
+  def inject_test_session(_context) do
+    {:ok, session} = start_test_session()
+
+    {:ok, %{session: session}}
   end
 
   defp default_opts_for_driver("phantom"), do: []

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -31,3 +31,4 @@ Code.require_file "cases/browser/visible_test.exs", __DIR__
 Code.require_file "cases/browser/window_size_test.exs", __DIR__
 Code.require_file "cases/element/send_keys_test.exs", __DIR__
 Code.require_file "cases/query_test.exs", __DIR__
+Code.require_file "cases/wallaby_test.exs", __DIR__

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -83,7 +83,8 @@ defmodule Wallaby.Phantom do
 
   @doc false
   def end_session(%Wallaby.Session{server: server}=session) do
-    Driver.execute_script(session, "localStorage.clear()")
+    Driver.execute_script(session, "localStorage.clear()", [],
+                          check_logs: false)
     Driver.delete(session)
     :poolboy.checkin(Wallaby.ServerPool, server)
   end


### PR DESCRIPTION
There's a few changes in here:

1. Added an integration test that ensures the driver allows calling `Wallaby.end_session/1` on a closed session. There was an issue in the phantom driver where the check_logs call would fail during end_session, so I added an option to skip checking logs. (I was getting a 404 `Variable Resource Not Found` response from phantom when it tried to check logs while clearing local storage during shutdown. I'm wondering if there's some async stuff going on here and if shutdown got in the way).
2. Set up an `on_exit` callback directly in `start_test_session`, so sessions created through this function are automatically shut down when the test exits.
3. Added a tag to `Wallaby.Integration.SessionCase` that allows us to be able to skip automatically generating a test session.