### PR TITLE
Fix issue with removing stale nodes from the DOM.

### DIFF
--- a/integration_test/cases/browser/stale_nodes_test.exs
+++ b/integration_test/cases/browser/stale_nodes_test.exs
@@ -17,7 +17,8 @@ defmodule Wallaby.Integration.Browser.StaleElementsTest do
         |> visit("stale_nodes.html")
         |> find(Query.css("#removed-node"))
 
-      Process.sleep(400) # let the node disappear via javascript
+      session
+      |> assert_has(Query.css("#removed-node", count: 0))
 
       assert_raise Wallaby.StaleReferenceException, fn ->
         Element.value(element)

--- a/integration_test/support/pages/stale_nodes.html
+++ b/integration_test/support/pages/stale_nodes.html
@@ -17,6 +17,6 @@
     setTimeout(function() {
       var node = document.getElementById('removed-node')
       node.remove()
-    }, 300)
+    }, 1000)
   </script>
 </html>


### PR DESCRIPTION
This PR fixes an unreliable test for stale nodes. Instead of using Proces.sleep I'm using `assert_has` to force the DOM to block until the node has been removed.