### PR TITLE
Remove deprecated version of text

### DIFF
--- a/integration_test/cases/browser/execute_script_test.exs
+++ b/integration_test/cases/browser/execute_script_test.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Integration.Browser.ExecuteScriptTest do
       |> visit("page_1.html")
       |> execute_script(@script, ["now you see me", "return value"])
       |> find(Query.css("#new-element"))
-      |> text == "now you see me"
+      |> Element.text == "now you see me"
   end
 
   test "executing scripts with arguments and callback returns session", %{session: session} do
@@ -26,7 +26,7 @@ defmodule Wallaby.Integration.Browser.ExecuteScriptTest do
       |> visit("page_1.html")
       |> execute_script(@script, ["now you see me", "return value"], fn(value) ->
            assert value == "return value"
-           send self, {:callback, value}
+           send self(), {:callback, value}
          end)
 
     assert result == session
@@ -35,6 +35,6 @@ defmodule Wallaby.Integration.Browser.ExecuteScriptTest do
 
     assert session
     |> find(Query.css("#new-element"))
-    |> text == "now you see me"
+    |> Element.text == "now you see me"
   end
 end

--- a/integration_test/cases/browser/find_test.exs
+++ b/integration_test/cases/browser/find_test.exs
@@ -35,7 +35,7 @@ defmodule Wallaby.Integration.Browser.FindTest do
         |> all(".user")
 
       assert Enum.count(users) == 3
-      assert List.first(users) |> text == "Chris"
+      assert List.first(users) |> Element.text == "Chris"
     end
 
     test "throws a not found error if the element could not be found", %{page: page} do

--- a/integration_test/cases/browser/text_test.exs
+++ b/integration_test/cases/browser/text_test.exs
@@ -6,7 +6,7 @@ defmodule Wallaby.Integration.Browser.TextTest do
       session
       |> visit("/")
       |> find(Query.css("#header"))
-      |> text()
+      |> Element.text()
 
     assert text == "Test Index"
   end
@@ -16,7 +16,7 @@ defmodule Wallaby.Integration.Browser.TextTest do
       session
       |> visit("/")
       |> find(Query.css("#parent"))
-      |> text()
+      |> Element.text()
 
     assert text == "The Parent\nThe Child"
   end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -475,11 +475,6 @@ defmodule Wallaby.Browser do
     |> find(Query.css("body"))
     |> Element.text()
   end
-  def text(%Element{}=element) do
-    IO.warn "text/1 has been deprecated. Please use Element.text/1"
-
-    Element.text(element)
-  end
 
   @doc """
   Gets the value of the elements attribute.


### PR DESCRIPTION
Removes the deprecated version of text. If you need to get the text of an Element you can do so by specifying `Element.text`.

I did question whether the session version of the function should be on `Browser` or `Element`. I see arguments for either. I left it on `Browser` for now but I'm open to other ideas.