### PR TITLE
Remove deprecated attach_file

### DIFF
--- a/integration_test/cases/browser/file_test.exs
+++ b/integration_test/cases/browser/file_test.exs
@@ -1,7 +1,7 @@
 defmodule Wallaby.Integration.Browser.FileTest do
   use Wallaby.Integration.SessionCase, async: true
 
-  import Wallaby.Query, only: [css: 1]
+  import Wallaby.Query, only: [css: 1, file_field: 1]
 
   setup %{session: session} do
     page =
@@ -14,21 +14,21 @@ defmodule Wallaby.Integration.Browser.FileTest do
   describe "attaching a file to a form" do
     test "by name", %{page: page} do
       page
-      |> attach_file("file_input", path: "integration_test/support/fixtures/file.txt")
+      |> attach_file(file_field("file_input"), path: "integration_test/support/fixtures/file.txt")
 
       assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
     end
 
     test "by DOM ID", %{page: page} do
       page
-      |> attach_file("file_field", path: "integration_test/support/fixtures/file.txt")
+      |> attach_file(file_field("file_field"), path: "integration_test/support/fixtures/file.txt")
 
       assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
     end
 
     test "by label", %{page: page} do
       page
-      |> attach_file("File", path: "integration_test/support/fixtures/file.txt")
+      |> attach_file(file_field("File"), path: "integration_test/support/fixtures/file.txt")
 
       assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
     end
@@ -36,29 +36,18 @@ defmodule Wallaby.Integration.Browser.FileTest do
 
   test "attaching a non-extant file does nothing", %{page: page} do
     page
-    |> attach_file("File", path: "integration_test/support/fixtures/fool.txt")
+    |> attach_file(file_field("File"), path: "integration_test/support/fixtures/fool.txt")
 
     assert find(page, css("#file_field")) |> has_value?("")
   end
 
   test "checks for labels without for attributes", %{page: page} do
     assert_raise Wallaby.QueryError, ~r/label has no 'for'/, fn ->
-      attach_file(page, "File field with bad label", path: "integration_test/support/fixtures/file.txt")
+      attach_file(page, file_field("File field with bad label"), path: "integration_test/support/fixtures/file.txt")
     end
   end
 
   test "escapes quotes", %{page: page} do
-    assert attach_file(page, "I'm a file field", path: "integration_test/support/fixtures/file.txt")
-  end
-
-  describe "attach_file/2" do
-    test "works with queries", %{page: page} do
-      assert page
-      |> attach_file(Query.file_field("File"), path: "integration_test/support/fixtures/file.txt")
-
-      assert page
-      |> find(Query.file_field("File"))
-      |> has_value?("C:\\fakepath\\file.txt")
-    end
+    assert attach_file(page, file_field("I'm a file field"), path: "integration_test/support/fixtures/file.txt")
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -234,19 +234,8 @@ defmodule Wallaby.Browser do
   Attaches a file to a file input. Input elements are looked up by id, label text,
   or name.
   """
-  @spec attach_file(parent, locator, opts) :: parent
-  @spec attach_file(parent, queryable, path: String.t) :: parent
+  @spec attach_file(parent, Query.t, path: String.t) :: parent
 
-  def attach_file(parent, locator, [{:path, value} | _]=opts) when is_binary(locator) do
-    IO.warn """
-    attach_file/3 with string locators has been deprecated. Please use:
-
-    attach_file(parent, Query.file_field("#{locator}"))
-    """
-
-    parent
-    |> fill_in(Query.file_field(locator, opts), with: :filename.absname(value))
-  end
   def attach_file(parent, query, path: path) do
     parent
     |> fill_in(query, with: :filename.absname(path))


### PR DESCRIPTION
Last one of the day. Removes the deprecated clauses for attach_file.