### PR TITLE
Fix test case for a button with no type via text

### DIFF
--- a/integration_test/cases/browser/click_button_test.exs
+++ b/integration_test/cases/browser/click_button_test.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
   test "clicking button with no type via button text (submits form)", %{page: page} do
     current_url =
       page
-      |> click(button("Submit button"))
+      |> click(button("button with no type"))
       |> IndexPage.ensure_page_loaded
       |> current_url
 


### PR DESCRIPTION
In the [fixtures](https://github.com/keathley/wallaby/blob/81d69ea/integration_test/support/pages/forms.html#L43-L44), this button's text is actually _button with no type_. The current text (_Submit button_) selects an element which belogs to [another](https://github.com/keathley/wallaby/blob/81d69ea/integration_test/cases/browser/click_button_test.exs#L48) test case: _clicking button type[submit] via button text_.