### PR TITLE
Fix bad button type error reporting.

### DIFF
--- a/integration_test/cases/browser/click_button_test.exs
+++ b/integration_test/cases/browser/click_button_test.exs
@@ -279,4 +279,12 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
   test "escapes quotes", %{page: page} do
     assert click(page, button("I'm a button"))
   end
+
+  test "with duplicate buttons", %{page: page} do
+    assert_raise Wallaby.QueryError, ~r/Expected (.*) 1/, fn ->
+      page
+      |> find(css(".duplicate-buttons"))
+      |> click(button("Duplicate Button"))
+    end
+  end
 end

--- a/integration_test/support/pages/forms.html
+++ b/integration_test/support/pages/forms.html
@@ -136,6 +136,10 @@
       </label>
     </div>
 
+    <div class="duplicate-buttons">
+      <button>Duplicate Button</button>
+      <button>Duplicate Button</button>
+    </div>
     <script>
       setTimeout(function() {
         document.querySelector('.js-hidden').style.display = 'block'

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -899,7 +899,7 @@ defmodule Wallaby.Browser do
     buttons = all(parent, Query.css("button", [text: query.selector]))
 
     cond do
-      Enum.any?(buttons) ->
+      Enum.count(buttons) == 1 && Enum.any?(buttons) ->
         {:error, :button_with_bad_type}
       true ->
         {:ok, query}


### PR DESCRIPTION
If there are duplicate buttons then Wallaby will incorrectly return an error saying that the button has a bad type. But the real error is that the specified count is incorrect. This PR adds a test for this case and fixes the underlying bug.