### PR TITLE
Remove deprecated version of visible?

### DIFF
--- a/integration_test/cases/browser/visible_test.exs
+++ b/integration_test/cases/browser/visible_test.exs
@@ -7,26 +7,26 @@ defmodule Wallaby.Integration.Browser.VisibleTest do
     test "determines if the element is visible to the user", %{page: page} do
       page
       |> find(Query.css("#visible"))
-      |> visible?
+      |> Element.visible?
       |> assert
 
       page
       |> find(Query.css("#invisible", visible: false))
-      |> visible?
+      |> Element.visible?
       |> refute
     end
 
     test "handles elements that are not on the page", %{page: page} do
       element = find(page, Query.css("#off-the-page", visible: false))
 
-      assert visible?(element) == false
+      assert Element.visible?(element) == false
     end
 
     @tag skip: "Unsuported in phantom"
     test "handles obscured elements", %{page: page} do
       element = find(page, Query.css("#obscured", visible: false))
 
-      assert visible?(element) == false
+      assert Element.visible?(element) == false
     end
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -498,13 +498,7 @@ defmodule Wallaby.Browser do
   Checks if the element is visible on the page
   """
   @spec visible?(parent, Query.t) :: boolean()
-  @spec visible?(Element.t) :: boolean()
 
-  def visible?(%Element{}=element) do
-    IO.warn "visible?/1 has been deprecated. Please use Element.visible?/1"
-
-    Element.visible?(element)
-  end
   def visible?(parent, query) do
     parent
     |> has?(query)


### PR DESCRIPTION
This PR removes the deprecated version of `visible?`.