### PR TITLE
Remove deprecated versions of click.

### DIFF
--- a/integration_test/cases/browser/click_button_test.exs
+++ b/integration_test/cases/browser/click_button_test.exs
@@ -279,4 +279,10 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
   test "escapes quotes", %{page: page} do
     assert click(page, button("I'm a button"))
   end
+
+  test "works with elements", %{page: page} do
+    assert page
+    |> find(button("I'm a button"))
+    |> Element.click()
+  end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -404,34 +404,10 @@ defmodule Wallaby.Browser do
   Clicks a element.
   """
   @spec click(parent, Query.t) :: parent
-  @spec click(Element.t) :: Element.t
 
-  def click(parent, locator) when is_binary(locator) do
-    IO.warn """
-    click/2 with string locator has been deprecated. Please use:
-
-    click(parent, Query.button("#{locator}"))
-    """
-
-    parent
-    |> find(Query.button(locator), &Element.click/1)
-  end
   def click(parent, query) do
     parent
     |> find(query, &Element.click/1)
-  end
-  def click(element) do
-    IO.warn "click/1 has been deprecated. Please use Element.click/1"
-
-    Element.click(element)
-  end
-
-  def click_on(parent, query) do
-    IO.warn """
-    click_on/2 has been deprecated. Please use Browser.click/2.
-    """
-
-    click(parent, query)
   end
 
   @doc """


### PR DESCRIPTION
Removes the deprecated versions of `click` and `click_on`.