### PR TITLE
Remove send_text

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -368,17 +368,6 @@ defmodule Wallaby.Browser do
     parent
   end
 
-  def send_text(parent, query, keys) do
-    IO.warn "send_text/3 has been deprecated. Please use send_keys/3"
-    send_keys(parent, query, keys)
-  end
-
-  def send_text(parent, keys) do
-    IO.warn "send_text/2 has been deprecated. Please use send_keys/2"
-    send_keys(parent, keys)
-  end
-
-
   @doc """
   Retrieves the source of the current page.
   """


### PR DESCRIPTION
Removes `send_text` from `Browser`.