### PR TITLE
Report duplicate html issues correctly.

### DIFF
--- a/integration_test/cases/browser/click_test.exs
+++ b/integration_test/cases/browser/click_test.exs
@@ -60,6 +60,12 @@ defmodule Wallaby.Integration.Browser.ClickTest do
       end
     end
 
+    test "throw an error if the query matches multiple labels", %{page: page} do
+      assert_raise Wallaby.QueryError, ~r/Expected (.*) 1/, fn ->
+        click(page, Query.radio_button("Duplicate Radiobutton"))
+      end
+    end
+
     test "waits until the radio button appears", %{page: page} do
       assert click(page, Query.radio_button("Hidden Radio Button"))
     end

--- a/integration_test/support/pages/forms.html
+++ b/integration_test/support/pages/forms.html
@@ -125,6 +125,17 @@
       <button type="button" name="button">I'm a button</button>
     </form>
 
+    <div class="duplicate-radio-buttons">
+      <label>
+        <input type="radio" value="duplicate-value">
+        Duplicate Radiobutton
+      </label>
+      <label>
+        <input type="radio" value="duplicate-value">
+        Duplicate Radiobutton
+      </label>
+    </div>
+
     <script>
       setTimeout(function() {
         document.querySelector('.js-hidden').style.display = 'block'

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -910,10 +910,13 @@ defmodule Wallaby.Browser do
     labels = all(parent, label_query)
 
     cond do
-      Enum.any?(labels, &(missing_for?(&1))) ->
-        {:error, :label_with_no_for}
-      label=List.first(labels) ->
-        {:error, {:label_does_not_find_field, Element.attr(label, "for")}}
+      Enum.count(labels) == 1 ->
+        cond do
+          Enum.any?(labels, &(missing_for?(&1))) ->
+            {:error, :label_with_no_for}
+          label=List.first(labels) ->
+            {:error, {:label_does_not_find_field, Element.attr(label, "for")}}
+        end
       true ->
         {:ok, query}
     end


### PR DESCRIPTION
This is similar to the issue with finding duplicate buttons. We're incorrectly reporting malformed labels when its really an issue with finding an incorrect amount of elements. This is noticeable when finding radio buttons and checkboxes.