### PR TITLE
Remove obscured test case as not working with phantom and selenium

### DIFF
--- a/integration_test/cases/browser/visible_test.exs
+++ b/integration_test/cases/browser/visible_test.exs
@@ -21,13 +21,6 @@ defmodule Wallaby.Integration.Browser.VisibleTest do
 
       assert Element.visible?(element) == false
     end
-
-    @tag skip: "Unsuported in phantom"
-    test "handles obscured elements", %{page: page} do
-      element = find(page, Query.css("#obscured", visible: false))
-
-      assert Element.visible?(element) == false
-    end
   end
 
   describe "visible?/2" do

--- a/integration_test/support/pages/page_1.html
+++ b/integration_test/support/pages/page_1.html
@@ -39,16 +39,6 @@
       <p id="visible">Visible</p>
       <p id="invisible" style="display:none">Invisible</p>
       <p id="off-the-page" style="position:absolute;top:-300px;">Off the page</p>
-      <div style="position:relative;width:100px;height:50px;">
-        <div style="position:absolute;top:0;left:0;right:0;bottom:0;background-color:red;">
-        </div>
-        <div id="obscured">
-          Obscured
-        </div>
-      </div>
-      <div id="fixed" style="position:fixed;left:100px;top:100px;width:100px;height:50px">
-        Fixed Position
-      </div>
     </div>
 
     <div class="inner-text">


### PR DESCRIPTION
* Follow up to #229
* @aaronrenner mentioned that it doesn't work on selenium either
  so not much sense in keeping it around sadly