### PR TITLE
Remove select and selected?/1 from Browser module.

### DIFF
--- a/integration_test/cases/browser/select_test.exs
+++ b/integration_test/cases/browser/select_test.exs
@@ -1,7 +1,7 @@
 defmodule Wallaby.Integration.Browser.SelectTest do
   use Wallaby.Integration.SessionCase, async: true
 
-  import Wallaby.Query, only: [css: 1]
+  import Wallaby.Query, only: [option: 1, select: 1]
 
   setup %{session: session} do
     page =
@@ -11,84 +11,26 @@ defmodule Wallaby.Integration.Browser.SelectTest do
     {:ok, page: page}
   end
 
-  test "choosing an option from a select box by id", %{page: page} do
-    refute find(page, css("#select-option-2")) |> selected?
-
-    page
-    |> select("select-box", option: "Option 2")
-
-    assert find(page, css("#select-option-2")) |> selected?
-  end
-
-  test "choosing an option from a select box by name", %{page: page} do
-    refute find(page, css("#select-option-5")) |> selected?
-
-    page
-    |> select("my-select", option: "Option 2")
-
-    assert find(page, css("#select-option-5")) |> selected?
-  end
-
-  test "choosing an option from a select box by label", %{page: page} do
-    refute find(page, css("#select-option-5")) |> selected?
-
-    page
-    |> select("My Select", option: "Option 2")
-
-    assert find(page, css("#select-option-5")) |> selected?
-  end
-
-  test "choosing an option from a select box by label when for is id", %{page: page} do
-    refute find(page, css("#select-option-2")) |> selected?
-
-    page
-    |> select("Select With ID", option: "Option 2")
-
-    assert find(page, css("#select-option-2")) |> selected?
-  end
-
-  test "throw an error if a label exists but does not have a for attribute", %{page: page} do
-    assert_raise Wallaby.QueryError, fn ->
-      select(page, "Select with bad label", option: "Option")
-    end
-  end
-
-  test "waits until the select appears", %{session: session} do
-    page =
-      session
-      |> visit("forms.html")
-
-    assert select(page, "Hidden Select", option: "Option")
-  end
-
   test "escapes quotes", %{page: page} do
-    assert select(page, "I'm a select", option: "I'm an option")
-  end
-
-  describe "select/2" do
-    test "works with option queries", %{page: page} do
-      assert page
-      |> find(Query.select("My Select"))
-      |> select(Query.option("Option 2"))
-    end
+    assert click(page, option("I'm an option"))
   end
 
   describe "selected?/2" do
     test "returns a boolean if the option is selected", %{page: page} do
       assert page
-      |> find(Query.select("My Select"))
-      |> select(Query.option("Option 2"))
-      |> selected?(Query.option("Option 2")) == true
+      |> find(select("My Select"))
+      |> click(option("Option 2"))
+      |> selected?(option("Option 2")) == true
     end
   end
 
   describe "selected?/1" do
     test "returns a boolean if the option is selected", %{page: page} do
       assert page
-      |> find(Query.select("My Select"))
-      |> select(Query.option("Option 2"))
-      |> find(Query.option("Option 2"))
-      |> selected? == true
+      |> find(select("My Select"))
+      |> click(option("Option 2"))
+      |> find(option("Option 2"))
+      |> Element.selected? == true
     end
   end
 end

--- a/integration_test/cases/browser/select_test.exs
+++ b/integration_test/cases/browser/select_test.exs
@@ -17,8 +17,14 @@ defmodule Wallaby.Integration.Browser.SelectTest do
 
   describe "selected?/2" do
     test "returns a boolean if the option is selected", %{page: page} do
-      assert page
-      |> find(select("My Select"))
+      select =
+        page
+        |> find(select("My Select"))
+
+      assert select
+      |> selected?(option("Option 2")) == false
+
+      assert select
       |> click(option("Option 2"))
       |> selected?(option("Option 2")) == true
     end
@@ -26,11 +32,11 @@ defmodule Wallaby.Integration.Browser.SelectTest do
 
   describe "selected?/1" do
     test "returns a boolean if the option is selected", %{page: page} do
-      assert page
+      page
       |> find(select("My Select"))
+      |> find(option("Option 2"), & refute Element.selected?(&1))
       |> click(option("Option 2"))
-      |> find(option("Option 2"))
-      |> Element.selected? == true
+      |> find(option("Option 2"), & assert Element.selected?(&1))
     end
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -171,40 +171,6 @@ defmodule Wallaby.Browser do
     |> find(query, &(Element.fill_in(&1, with: value)))
   end
 
-  @doc """
-  Selects an option from a select box. The select box can be found by id, label
-  text, or name. The option can be found by its text.
-  """
-  @spec select(Element.t) :: Element.t
-  @spec select(parent, Query.t) :: parent
-  @spec select(parent, Query.t, from: Query.t) :: parent
-  @spec select(parent, locator, opts) :: parent
-
-  def select(element) do
-    IO.warn "select/1 has been deprecated. Please use Element.click/1"
-
-    Element.click(element)
-  end
-  def select(parent, query) do
-    IO.warn "select/2 has been deprecated. Please use click/2"
-
-    parent
-    |> find(query, &Element.click/1)
-  end
-  def select(parent, locator, [option: option_text]=opts) do
-    IO.warn """
-    select/3 has been deprecated. Please use:
-
-    click(parent, Query.option("#{option_text}"))
-    """
-
-    find(parent, Query.select(locator, opts), fn(select_field) ->
-      find(select_field, Query.option(option_text, []), fn(option) ->
-        Element.click(option)
-      end)
-    end)
-  end
-
   # @doc """
   # Clears an input field. Input elements are looked up by id, label text, or name.
   # The element can also be passed in directly.
@@ -419,17 +385,11 @@ defmodule Wallaby.Browser do
   Checks if the element has been selected. Alias for checked?(element)
   """
   @spec selected?(parent, Query.t) :: boolean()
-  @spec selected?(Element.t) :: boolean()
 
   def selected?(parent, query) do
     parent
     |> find(query)
     |> Element.selected?
-  end
-  def selected?(%Element{}=element) do
-    IO.warn "selected?/1 has been deprecated. Please use Element.selected?/1"
-
-    Element.selected?(element)
   end
 
   @doc """


### PR DESCRIPTION
This PR removes the `select` functions and `selected?/1` from the Browser module. It would be very nice to have some sort of query composition for finding options inside of a given select. Because there are multiple "Option 2" options on the page you get a duplicate element error if you don't scope everything to the specific select.