### PR TITLE
Fix example html `users` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ DOM.
 Lets say that our html looks like this:
 
 ```html
-<ul class=".users">
+<ul class="users">
   <li class="user">
     <span class="user-name">Ada</span>
   </li>


### PR DESCRIPTION
The example has a class of `.users` instead of `users`