### PR TITLE
Capture invalid element state errors.

### DIFF
--- a/integration_test/cases/browser/invalid_selectors_test.exs
+++ b/integration_test/cases/browser/invalid_selectors_test.exs
@@ -1,0 +1,19 @@
+defmodule Wallaby.Integration.Browser.InvalidSelectorsTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  import Wallaby.Query, only: [css: 1, file_field: 1]
+
+  describe "with an invalid selector state" do
+    test "find returns an exception", %{session: session} do
+      assert_raise Wallaby.QueryError, ~r/The css 'checkbox:foo' is not a valid query/, fn ->
+        find(session, css("checkbox:foo"))
+      end
+    end
+
+    test "assert_has returns an exception", %{session: session} do
+      assert_raise Wallaby.QueryError, ~r/The css 'checkbox:foo' is not a valid query/, fn ->
+        assert_has(session, css("checkbox:foo"))
+      end
+    end
+  end
+end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -27,8 +27,10 @@ defmodule Wallaby.Element do
 
   defstruct [:url, :session_url, :parent, :id, :driver, screenshots: []]
 
-  @opaque value :: String.t | number()
-
+  @type value :: String.t
+               | number()
+               | :selected
+               | :unselected
   @type attr :: String.t
   @type keys_to_send :: String.t | list(atom | String.t)
   @type t :: %__MODULE__{
@@ -48,8 +50,10 @@ defmodule Wallaby.Element do
     case driver.clear(element) do
       {:ok, _} ->
         element
-      {:error, _} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
+      {:error, :invalid_selector} ->
+        raise Wallaby.InvalidSelector
     end
   end
 
@@ -76,7 +80,7 @@ defmodule Wallaby.Element do
     case driver.click(element) do
       {:ok, _} ->
         element
-      {:error, _} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
     end
   end
@@ -90,7 +94,7 @@ defmodule Wallaby.Element do
     case driver.text(element) do
       {:ok, text} ->
         text
-      {:error, :stale_reference_error} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
     end
   end
@@ -104,7 +108,7 @@ defmodule Wallaby.Element do
     case driver.attribute(element, name) do
       {:ok, attribute} ->
         attribute
-      {:error, _} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
     end
   end
@@ -151,8 +155,9 @@ defmodule Wallaby.Element do
     case driver.set_value(element, value) do
       {:ok, _} ->
         element
-      {:error, :stale_reference_error} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
+      error -> error
     end
   end
 
@@ -168,8 +173,9 @@ defmodule Wallaby.Element do
     case driver.send_keys(element, keys) do
       {:ok, _} ->
         element
-      {:error, :stale_reference_error} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
+      error -> error
     end
   end
 

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -66,13 +66,8 @@ end
 defmodule Wallaby.InvalidSelector do
   defexception [:message]
 
-  @spec exception(%{}) :: Exception.t
-  def exception(%{"using" => method, "value" => selector}) do
-    msg = """
-    The #{method} '#{selector}' is invalid.
-    """
-
-    %__MODULE__{message: msg}
+  def exception(_) do
+    %__MODULE__{message: "Shit is broken and invalid yo"}
   end
 end
 

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -143,7 +143,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   For Checkboxes and Radio buttons it returns the selected option.
   For options selects it returns the selected option
   """
-  @spec selected(Element.t) :: {:ok, boolean} | {:error, :stale_reference_error}
+  @spec selected(Element.t) :: {:ok, boolean} | {:error, :stale_reference}
   def selected(element) do
     with {:ok, resp} <- request(:get, "#{element.url}/selected"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -156,7 +156,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   This is based on what is available in phantom and doesn't match the current
   specification.
   """
-  @spec displayed(Element.t) :: {:ok, boolean} | {:error, :stale_reference_error}
+  @spec displayed(Element.t) :: {:ok, boolean} | {:error, :stale_reference}
   def displayed(element) do
     with {:ok, resp} <- request(:get, "#{element.url}/displayed"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -301,7 +301,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   response.
   """
   @spec request(http_method, url, map | String.t, [request_opts]) ::
-    {:ok, any} | {:error, :stale_reference_error | :invalid_selector}
+    {:ok, any} | {:error, :stale_reference | :invalid_selector}
   def request(method, url, params \\ %{}, opts \\ [])
   def request(method, url, params, _opts) when map_size(params) == 0 do
     make_request(method, url, "")
@@ -332,7 +332,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
       {:ok, resp} ->
         resp
 
-      {:error, :stale_reference_error} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
 
       {:error, :invalid_selector} ->
@@ -366,7 +366,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   defp check_for_response_errors(response) do
     case Map.get(response, "value") do
       %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
-        {:error, :stale_reference_error}
+        {:error, :stale_reference}
       %{"class" => "org.openqa.selenium.InvalidSelectorException"} ->
         {:error, :invalid_selector}
       _ ->

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -13,7 +13,7 @@ defmodule Wallaby.Phantom.Driver do
 
   @type response_errors ::
     {:error, :invalid_selector} |
-    {:error, :stale_reference_error}
+    {:error, :stale_reference}
 
   @spec create(pid, Keyword.t) :: {:ok, Session.t}
   def create(server, opts) do
@@ -211,7 +211,7 @@ defmodule Wallaby.Phantom.Driver do
         {:ok, value} ->
           value
 
-        {:error, :stale_reference_error} ->
+        {:error, :stale_reference} ->
           raise Wallaby.StaleReferenceException
       end
     end
@@ -544,7 +544,7 @@ defmodule Wallaby.Phantom.Driver do
       {:ok, resp} ->
         resp
 
-      {:error, :stale_reference_error} ->
+      {:error, :stale_reference} ->
         raise Wallaby.StaleReferenceException
 
       {:error, :invalid_selector} ->
@@ -559,8 +559,10 @@ defmodule Wallaby.Phantom.Driver do
   def check_for_response_errors(response) do
     case Map.get(response, "value") do
       %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
-        {:error, :stale_reference_error}
+        {:error, :stale_reference}
       %{"class" => "org.openqa.selenium.InvalidSelectorException"} ->
+        {:error, :invalid_selector}
+      %{"class" => "org.openqa.selenium.InvalidElementStateException"} ->
         {:error, :invalid_selector}
       _ ->
         {:ok, response}

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -52,6 +52,11 @@ defmodule Wallaby.Query.ErrorMessage do
     The query is invalid. Cannot set the minimum greater than the maximum.
     """
   end
+  def message(%{method: method, selector: selector}, :invalid_selector) do
+    """
+    The #{method} '#{selector}' is not a valid query.
+    """
+  end
 
   def help(elements) do
     """

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -52,7 +52,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:error, :stale_reference_error} =
+      assert {:error, :stale_reference} =
         Client.request(:post, bypass_url(bypass, "/my_url"))
     end
   end
@@ -269,7 +269,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:error, :stale_reference_error} = Client.set_value(element, value)
+      assert {:error, :stale_reference} = Client.set_value(element, value)
     end
   end
 
@@ -340,7 +340,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:error, :stale_reference_error} = Client.clear(element)
+      assert {:error, :stale_reference} = Client.clear(element)
     end
   end
 
@@ -562,7 +562,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:error, :stale_reference_error} = Client.displayed(element)
+      assert {:error, :stale_reference} = Client.displayed(element)
     end
   end
 

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -388,7 +388,7 @@ defmodule Wallaby.Phantom.DriverTest do
         end
       end
 
-      assert {:error, :stale_reference_error} = Driver.displayed(element)
+      assert {:error, :stale_reference} = Driver.displayed(element)
     end
   end
 


### PR DESCRIPTION
This PR allows us to capture invalid element state errors coming from the driver. Typically you see this if you try to use an element state selector incorrectly. I noticed it when I accidentally typoed this selector:

```
css(".checkbox-group .checkbox input[data-size-id-toggle=\"#{size}\"]:checkbox")
```

`:checkbox` isn't a valid state. I meant to say `:checked`. We don't handle this gracefully. Instead it just dumps the stack trace. I've changed it to provide better feedback to the user.

Currently this only checks the error in `assert_has` which is where I noticed it. I still need to add tests to make sure that this error isn't present in `find` as well. I'm also considering throwing the error from the driver. It seems like if we see this error we want to stop since retrying won't do the user any good.