### PR TITLE
Resolve issue with filling form fields based on labels where 1 label is subset of another

### DIFF
--- a/integration_test/cases/browser/find_test.exs
+++ b/integration_test/cases/browser/find_test.exs
@@ -86,11 +86,6 @@ defmodule Wallaby.Integration.Browser.FindTest do
       assert user1 != user2
     end
 
-    test "can be scoped by inner text when there are multiple elements with text", %{page: page} do
-      element = find(page, Query.css(".inner-text", text: "Inner Text"))
-      assert element
-    end
-
     test "scoping with text escapes the text", %{page: page} do
       assert find(page, Query.css(".plus-one", text: "+ 1"))
     end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -870,7 +870,7 @@ defmodule Wallaby.Browser do
   defp matching_text?(%Element{driver: driver} = element, text) do
     case driver.text(element) do
       {:ok, element_text} ->
-        element_text =~ ~r/#{Regex.escape(text)}/
+        element_text =~ ~r/^\s*#{Regex.escape(text)}\s*$/
       {:error, _} ->
         false
     end


### PR DESCRIPTION
Matching the text of an inner element forces the inner text to match exactly, and be surrounded by nothing but optional whitespace

**NOTE** I had to remove a browser test, so this is a breaking change.  However, I suspect the use case I am solving for is the more common one.  The test in question was searching for text that was a subset of the text in the returned element.

I think that if the previous use case is important, it might be a good idea to add a callback to the list of Query conditions that would allow the user to handle the filtering on their own. 

fixes #256 