### PR TITLE
Fixed issue when no value field in response

### DIFF
--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -3,7 +3,7 @@ defmodule Wallaby.Experimental.Selenium do
 
   @behaviour Wallaby.Driver
 
-  alias Wallaby.{Element, Session}
+  alias Wallaby.{Driver, Element, Session}
   alias Wallaby.Experimental.Selenium.WebdriverClient
 
   @type start_session_opts ::
@@ -107,6 +107,7 @@ defmodule Wallaby.Experimental.Selenium do
     WebdriverClient.attribute(element, name)
   end
 
+  @spec clear(Element.t) :: {:ok, nil} | {:error, Driver.reason}
   def clear(%Element{} = element) do
     WebdriverClient.clear(element)
   end
@@ -123,6 +124,7 @@ defmodule Wallaby.Experimental.Selenium do
     WebdriverClient.selected(element)
   end
 
+  @spec set_value(Element.t, String.t) :: {:ok, nil} | {:error, Driver.reason}
   def set_value(%Element{} = element, value) do
     WebdriverClient.set_value(element, value)
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -1,6 +1,6 @@
 defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @moduledoc false
-  alias Wallaby.{Element, Query, Session}
+  alias Wallaby.{Driver, Element, Query, Session}
 
   @type http_method :: :post | :get | :delete
   @type url :: String.t
@@ -38,21 +38,23 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Sets the value of an element.
   """
-  @spec set_value(Element.t, String.t) :: {:ok, nil}
+  @spec set_value(Element.t, String.t) :: {:ok, nil} | {:error, Driver.reason}
   def set_value(%Element{url: url}, value) do
-    with  {:ok, resp} <- request(:post, "#{url}/value", %{value: [value]}),
-          {:ok, value} <- Map.fetch(resp, "value"),
-      do: {:ok, value}
+    case request(:post, "#{url}/value", %{value: [value]}) do
+      {:ok, resp} -> {:ok, Map.get(resp, "value")}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """
   Clears the value in an element
   """
-  @spec clear(Element.t) :: {:ok, nil}
+  @spec clear(Element.t) :: {:ok, nil} | {:error, Driver.reason}
   def clear(%Element{url: url}) do
-    with {:ok, resp} <- request(:post, "#{url}/clear"),
-          {:ok, value} <- Map.fetch(resp, "value"),
-      do: {:ok, value}
+    case request(:post, "#{url}/clear") do
+      {:ok, resp} -> {:ok, Map.get(resp, "value")}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """


### PR DESCRIPTION
I was running wallaby + selenium against Browserstack and saw this issue when testing on iPad 2 (ios 5.0). This also adds a few more typespecs.