### PR TITLE
Monitor and demonitor sessions for all browsers.

### DIFF
--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -20,8 +20,7 @@ defmodule Wallaby.Integration.SessionCase do
       |> Keyword.merge(opts)
 
     with {:ok, session} <- retry(2, fn -> Wallaby.start_session(session_opts) end),
-        :ok <- on_exit(fn -> Wallaby.end_session(session) end),
-        do: {:ok, session}
+      do: {:ok, session}
   end
 
   @doc """

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Experimental.Chrome do
   @chromedriver_version_regex ~r/^ChromeDriver 2\.(\d+).(\d+) \(.*\)/
 
   alias Wallaby.Session
-  alias Wallaby.Experimental.Chrome.{Chromedriver, Sessions}
+  alias Wallaby.Experimental.Chrome.{Chromedriver}
   alias Wallaby.Experimental.Selenium.WebdriverClient
 
   @doc false
@@ -17,7 +17,6 @@ defmodule Wallaby.Experimental.Chrome do
   def init(:ok) do
     children = [
       :poolboy.child_spec(@pool_name, poolboy_config(), []),
-      worker(Wallaby.Experimental.Chrome.Sessions, [])
     ]
 
     supervise(children, strategy: :one_for_one)
@@ -73,7 +72,6 @@ defmodule Wallaby.Experimental.Chrome do
         driver: __MODULE__,
         server: chromedriver,
       }
-      :ok = Sessions.monitor(session)
 
       {:ok, session}
     end

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -2,7 +2,6 @@ defmodule Wallaby.Experimental.Chrome do
   use Supervisor
   @behaviour Wallaby.Driver
 
-  @pool_name Wallaby.ChromedriverPool
   @chromedriver_version_regex ~r/^ChromeDriver 2\.(\d+).(\d+) \(.*\)/
 
   alias Wallaby.Session
@@ -16,7 +15,7 @@ defmodule Wallaby.Experimental.Chrome do
 
   def init(:ok) do
     children = [
-      :poolboy.child_spec(@pool_name, poolboy_config(), []),
+      worker(Wallaby.Experimental.Chrome.Chromedriver, [])
     ]
 
     supervise(children, strategy: :one_for_one)
@@ -49,13 +48,8 @@ defmodule Wallaby.Experimental.Chrome do
     end
   end
 
-  def start_session(opts \\ []) do
-    chromedriver = :poolboy.checkout(@pool_name, true, :infinity)
-    start_session(chromedriver, opts)
-  end
-
-  def start_session(chromedriver, opts) do
-    {:ok, base_url} = Chromedriver.base_url(chromedriver)
+  def start_session(opts) do
+    {:ok, base_url} = Chromedriver.base_url()
     capabilities = Keyword.get(opts, :capabilities, %{})
     create_session_fn = Keyword.get(opts, :create_session_fn,
                                     &WebdriverClient.create_session/2)
@@ -70,17 +64,16 @@ defmodule Wallaby.Experimental.Chrome do
         url: base_url <> "session/#{id}",
         id: id,
         driver: __MODULE__,
-        server: chromedriver,
+        server: Chromedriver,
       }
 
       {:ok, session}
     end
   end
 
-  def end_session(%Wallaby.Session{server: server}=session, opts \\ []) do
+  def end_session(%Wallaby.Session{}=session, opts \\ []) do
     end_session_fn = Keyword.get(opts, :end_session_fn, &WebdriverClient.delete_session/1)
     end_session_fn.(session)
-    :poolboy.checkin(@pool_name, server)
     :ok
   end
 
@@ -200,15 +193,4 @@ defmodule Wallaby.Experimental.Chrome do
       []
     end
   end
-
-  defp poolboy_config(), do: [
-    name: {:local, @pool_name},
-    worker_module: Wallaby.Experimental.Chrome.Chromedriver,
-    size: pool_size(),
-    max_overflow: 0,
-  ]
-
-  defp pool_size, do: Application.get_env(:wallaby, :pool_size) || default_pool_size()
-
-  defp default_pool_size, do: :erlang.system_info(:schedulers_online)/2
 end

--- a/lib/wallaby/experimental/chrome/chromedriver.ex
+++ b/lib/wallaby/experimental/chrome/chromedriver.ex
@@ -1,16 +1,16 @@
 defmodule Wallaby.Experimental.Chrome.Chromedriver do
   use GenServer
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [])
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 
-  def stop(server) do
-    GenServer.stop(server)
+  def stop() do
+    GenServer.stop(__MODULE__)
   end
 
-  def base_url(server) do
-    GenServer.call(server, :base_url)
+  def base_url() do
+    GenServer.call(__MODULE__, :base_url)
   end
 
   @dialyzer {:nowarn_function, init: 1}


### PR DESCRIPTION
This is the same logic that we use to kill chrome sessions. I've generalized it and made it work for all browsers. The solution is to monitor the processes the starts a session. If we detect a DOWN signal from that process then we kill the session ourselves. If the process calls `end_session` then we demonitor the process and allow wallaby to close the session.

This should fix #269 and #174.