### PR TITLE
Add the correct error message for text queries

### DIFF
--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -113,6 +113,8 @@ defmodule Wallaby.Query.ErrorMessage do
   def method(:file_field, true), do: "file fields"
   def method(:file_field, false), do: "file field"
 
+  def method(:text, true), do: "elements with the text"
+  def method(:text, false), do: "element with the text"
 
   def short_method(:css, count) when count > 1,  do: "elements"
   def short_method(:css, count) when count == 0, do: "elements"

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -91,6 +91,24 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message =~ ~r/query is invalid/
     end
+
+    test "with text queries" do
+      message =
+        Query.text("test")
+        |> ErrorMessage.message(:not_found)
+        |> format
+      assert message == format """
+      Expected to find 1, visible element with the text 'test' but 0, visible elements with the text were found.
+      """
+
+      message =
+        Query.text("test", count: 2)
+        |> ErrorMessage.message(:not_found)
+        |> format
+      assert message == format """
+      Expected to find 2, visible elements with the text 'test' but 0, visible elements with the text were found.
+      """
+    end
   end
 
   describe "visibility/1" do


### PR DESCRIPTION
We didn't have a matching function for displaying text query errors.

This fixes #283