### PR TITLE
Handle alerts in chrome #277

### DIFF
--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -98,12 +98,15 @@ defmodule Wallaby.Experimental.Chrome do
 
   def accept_dialogs(_session), do: {:error, :not_implemented}
   def dismiss_dialogs(_session), do: {:error, :not_implemented}
-  def accept_alert(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_alert(_session, _fun), do: {:error, :not_implemented}
-  def accept_confirm(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_confirm(_session, _fun), do: {:error, :not_implemented}
-  def accept_prompt(_session, _input, _fun), do: {:error, :not_implemented}
-  def dismiss_prompt(_session, _fun), do: {:error, :not_implemented}
+  
+  defdelegate accept_alert(session, fun),                        to: WebdriverClient
+  defdelegate dismiss_alert(session, fun),                       to: WebdriverClient
+  defdelegate accept_confirm(session, fun),                      to: WebdriverClient  
+  defdelegate dismiss_confirm(session, fun),                     to: WebdriverClient
+  defdelegate accept_prompt(session, input, fun),                to: WebdriverClient
+  defdelegate dismiss_prompt(session, fun),                      to: WebdriverClient
+
+
   @doc false
   defdelegate cookies(session),                                   to: WebdriverClient
   @doc false
@@ -201,4 +204,5 @@ defmodule Wallaby.Experimental.Chrome do
       []
     end
   end
+
 end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -365,9 +365,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
     }
   end
 
-  @doc """
-  Retrieves the text from an alert, prompt or confirm.
-  """
+  # Retrieves the text from an alert, prompt or confirm.
   @spec alert_text(Session.t) :: {:ok, String.t}
   defp alert_text(session) do
     with  {:ok, resp} <- request(:get, "#{session.url}/alert_text"),


### PR DESCRIPTION
Hi Chris,

As per our chat earlier, I Implemented the following:

```elixir
accept_alert/2, dismiss_alert/2, accept_confirm/2,
dismiss_confirm/2, accept_prompt/3, dismiss_prompt/2
```

And the following tests, are all passing:

```sh
WALLABY_DRIVER=chrome mix test integration_test/cases/browser/dialog_test.exs:96
WALLABY_DRIVER=chrome mix test integration_test/cases/browser/dialog_test.exs:111
WALLABY_DRIVER=chrome mix test integration_test/cases/browser/dialog_test.exs:139
WALLABY_DRIVER=chrome mix test integration_test/cases/browser/dialog_test.exs:164
``` 
However, there is a caveat: 

 - can't open a dialog/alert/prompt in ChromeDriver 2.30.477690, when in headless mode (OSX here). Probably it works,  if using Xvfb ... but it sucks :/
 
The tests above and the implementation so far, work with the :chrome option [headless: false]

Can't test the whole `dialog_test.exs` suite until we clarify the future functionality of `accept_dialogs/1` and  `dismiss_dialogs/1`, as today these two are very phantomjs-oriented :) Have the code for chrome, but it is incompatible with the current tests, as we discussed.

I believe chrome (2.30) doesn't love me anymore. 
