### PR TITLE
Reduce number of travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 language: elixir
+elixir:
+  - 1.4.5
+  - 1.3.4
+  - 1.5.0
+otp_release:
+  - 19.3
+  - 18.3
+  - 20.0
 matrix:
-  include:
+  exclude:
     - elixir: 1.3.4
+      otp_release: 19.3
+    - elixir: 1.3.4
+      otp_release: 20.0
+    - elixir: 1.4.5
       otp_release: 18.3
     - elixir: 1.4.5
-      otp_release: 19.3
-    - elixir: 1.5.0
       otp_release: 20.0
+    - elixir: 1.5.0
+      otp_release: 18.3
+    - elixir: 1.5.0
+      otp_release: 19.3
 env:
   - ""
   - WALLABY_DRIVER=phantom

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
 
 script:
   - mix coveralls.travis
-  - if [ -z ${WALLABY_DRIVER} ]; mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
+  - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
 
 after_script:
   - mix deps.get --only docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: elixir
-elixir:
-  - 1.4.5
-  - 1.3.4
-  - 1.5.0
-otp_release:
-  - 19.3
-  - 18.3
-  - 20.0
 matrix:
-  exclude:
+  include:
     - elixir: 1.3.4
+      otp_release: 18.3
+    - elixir: 1.4.5
+      otp_release: 19.3
+    - elixir: 1.5.0
       otp_release: 20.0
+env:
+  - ""
+  - WALLABY_DRIVER=phantom
+  - WALLABY_DRIVER=chrome
+  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=3
+  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=2
 # Run in bigger container so we don't run out of memory generating the plt
 sudo: required
 cache:
@@ -33,23 +35,16 @@ before_script:
   - sudo apt-get install google-chrome-beta
   - sudo apt-get install libstdc++6-4.7-dev
   - MIX_ENV=test mix compile --warnings-as-errors
+  - if [ -z ${WALLABY_DRIVER} ]; then travis_wait mix dialyzer --plt; fi # only run dialyzer for the env without drivers
   - bash $TRAVIS_BUILD_DIR/test/tools/start_webdriver.sh
 
 script:
   - mix coveralls.travis
-  - # skip dialyzer for elixir 1.4 and erlang 18 as it produces weird errors, see #69
-  - if [ -z ${WALLABY_DRIVER} ] && ! ([[ "$TRAVIS_ELIXIR_VERSION" == "1.4"* ]] && [[ "$TRAVIS_OTP_RELEASE" == "18"* ]]); then mix dialyzer --halt-exit-status; fi
+  - if [ -z ${WALLABY_DRIVER} ]; mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
 
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report
-
-env:
-  - ""
-  - WALLABY_DRIVER=phantom
-  - WALLABY_DRIVER=chrome
-  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=3
-  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=2
 
 before_install:
   - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"


### PR DESCRIPTION
Right now we generate [40](https://travis-ci.org/keathley/wallaby/builds/257458811) travis builds. That is a bit too much, I don't want my Travis friends to come over and be like "Tobi, you are using up all our resources!"
On a more serious note, we should fairly use our given free resources. Also, we sometimes have weird troubles downloading drivers etc. (which we should try to fix) but the more builds we have the more likely this is to occur and then we gotta restart etc... also, of course - it takes quite long.

So, of all the things we test what can we let go off?

* We need to test all drivers
* we need to test all elixir versions
* We need to test all combinations of drivers and elixir versions as they might execute different code from our driver integration and I wanna avoid issues where we start calling methods that don't exist yet in 1.3 for instance 

So, what can we do? Well my suggestion is this: Run each elixir version with its "dedicated" OTP release:
* 1.3 on 18,
* 1.4 on 19
* 1.5 on 20

that way we test all dirvers on all elixir versions, we test all otp releases, the only thing that might bite us is a bug that just occurs with elixir 1.5 and erlang 18 for instance which I think is the least likely to occur.

What do you think?

I hope my changes create the build matrix I imagine :D