### PR TITLE
Relax httpoison dependncy

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Wallaby.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.12.0"},
+      {:httpoison, "~> 0.12"},
       {:poison, ">= 1.4.0"},
       {:poolboy, "~> 1.5"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},


### PR DESCRIPTION
I just had some trouble upgrading wallaby due to our minor level strict dependency on httpoison, I think we should be good just relying on the minor. Wdyt?