### PR TITLE
Fixes visit/2 issue where urls have too many slashes

### DIFF
--- a/integration_test/cases/browser/navigation_test.exs
+++ b/integration_test/cases/browser/navigation_test.exs
@@ -11,18 +11,6 @@ defmodule Wallaby.Integration.Browser.NavigationTest do
     assert element
   end
 
-  test "visit/2 with a relative url and no base url raises exception", %{session: session} do
-    original_url = Application.get_env(:wallaby, :base_url)
-
-    assert_raise(Wallaby.NoBaseUrl, fn ->
-      Application.put_env(:wallaby, :base_url, nil)
-      session
-      |> visit("/page_1.html")
-    end)
-
-    Application.put_env(:wallaby, :base_url, original_url)
-  end
-
   test "visit/2 with an absolute path does not use the base url", %{session: session} do
     session
     |> visit("/page_1.html")

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -937,7 +937,10 @@ defmodule Wallaby.Browser do
   end
 
   defp request_url(path) do
-    base_url() <> path
+    base_url = String.trim_trailing(base_url(), "/")
+    path = String.trim_leading(path, "/")
+
+    "#{base_url}/#{path}"
   end
 
   defp base_url do

--- a/test/support/settings_test_helpers.ex
+++ b/test/support/settings_test_helpers.ex
@@ -1,0 +1,21 @@
+defmodule Wallaby.SettingsTestHelpers do
+  @moduledoc """
+  Test helpers for working with app environments
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @doc """
+  Ensures a setting is reset for the app's environment after the test is run.
+  """
+  def ensure_setting_is_reset(app, setting) do
+    orig_result = Application.fetch_env(app, setting)
+
+    on_exit fn -> reset_env(orig_result, app, setting) end
+  end
+
+  defp reset_env({:ok, orig}, app, setting) do
+    Application.put_env(app, setting, orig)
+  end
+  defp reset_env(:error, app, setting), do: Application.delete_env(app, setting)
+end

--- a/test/wallaby/browser_test.exs
+++ b/test/wallaby/browser_test.exs
@@ -1,7 +1,122 @@
 defmodule Wallaby.BrowserTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+
+  import Wallaby.SettingsTestHelpers
 
   alias Wallaby.Browser
+  alias Wallaby.Session
+
+  defmodule TestDriver do
+
+    def start_link() do
+      Agent.start_link(fn -> [] end, name: __MODULE__)
+    end
+
+    def visit(%Session{} = session, path) do
+      Agent.update(__MODULE__, fn (visits) ->
+        [path | visits]
+      end)
+      session
+    end
+
+    def assert_visited(url) do
+      unless Enum.member?(visits(), url) do
+        raise ExUnit.AssertionError,
+          """
+          #{inspect url} was not visited.
+
+          Visited urls:
+          #{visits() |> Enum.map(&"  #{inspect &1}") |> Enum.join("\n")}
+          """
+      end
+    end
+
+    defp visits do
+      Agent.get(__MODULE__, fn (visits) -> visits end)
+    end
+  end
+
+  describe "visit/2" do
+    setup do
+      ensure_setting_is_reset(:wallaby, :base_url)
+      {:ok, _} = TestDriver.start_link()
+      :ok
+    end
+
+    test "relative path without leading slash, base url with trailing slash" do
+      Application.put_env(:wallaby, :base_url, "http://example.com/")
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, "form.html")
+
+      TestDriver.assert_visited("http://example.com/form.html")
+    end
+
+    test "relative path with leading slash, base url no trailing slash" do
+      Application.put_env(:wallaby, :base_url, "http://example.com")
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, "/form.html")
+
+      TestDriver.assert_visited("http://example.com/form.html")
+    end
+
+    test "relative path without leading slash, base url no trailing slash" do
+      Application.put_env(:wallaby, :base_url, "http://example.com")
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, "form.html")
+
+      TestDriver.assert_visited("http://example.com/form.html")
+    end
+
+    test "relative path with leading slash, base url trailing slash" do
+      Application.put_env(:wallaby, :base_url, "http://example.com/")
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, "/form.html")
+
+      TestDriver.assert_visited("http://example.com/form.html")
+    end
+
+    test "relative path with leading slash, base url ending in /api" do
+      Application.put_env(:wallaby, :base_url, "https://example.com:9090/api/")
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, "/form.html?something=2")
+
+      TestDriver.assert_visited("https://example.com:9090/api/form.html?something=2")
+    end
+
+    test "relative url when the base_url isn't configured" do
+      Application.delete_env(:wallaby, :base_url)
+
+      assert_raise Wallaby.NoBaseUrl, fn ->
+        session = session_for_driver(TestDriver)
+        Browser.visit(session, "/form.html")
+      end
+    end
+
+    test "absolute url when the base_url isn't configured" do
+      Application.delete_env(:wallaby, :base_url)
+      uri = "https://example.com:9090/api/form.html"
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, uri)
+
+      TestDriver.assert_visited(uri)
+    end
+
+    test "absolute url when the base_url is configured" do
+      Application.put_env(:wallaby, :base_url, "http://example.org:5555/test")
+      uri = "https://example.com:9090/api/form.html"
+
+      session = session_for_driver(TestDriver)
+      Browser.visit(session, uri)
+
+      TestDriver.assert_visited(uri)
+    end
+  end
 
   describe "retry/2" do
     test "returns a valid result" do
@@ -23,5 +138,9 @@ defmodule Wallaby.BrowserTest do
     test "it retries until time runs out" do
       assert Browser.retry(fn -> {:error, :some_error} end) == {:error, :some_error}
     end
+  end
+
+  defp session_for_driver(driver) do
+    %Session{driver: driver}
   end
 end


### PR DESCRIPTION
I noticed in #300 that `visit/2` is generating urls like http://localhost:54579//logs.html that have too many slashes. This occurs when the base_url has a trailing slash and the requested path has a leading slash. This change adds tests and fixes the issue so we don't end up with urls with too many or not enough slashes depending on how these settings are configured.