### PR TITLE
Remove backup .tool-versions-e file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /deps
 erl_crash.dump
 *.ez
+/.tool-versions-e
 
 /screenshots
 /doc

--- a/.tool-versions-e
+++ b/.tool-versions-e
@@ -1,2 +1,0 @@
-elixir 1.4.2
-erlang 20.0


### PR DESCRIPTION
`.tool-versions-e` is just a backup file created by asdf when changing dependency versions. This file can be safely ignored from version control.