### PR TITLE
Document the Query module, especially specific queries

### DIFF
--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -54,6 +54,20 @@ defmodule Wallaby.Query do
     end
   end
   ```
+
+  ## What does my query do?
+
+  Wanna check out what exactly your query will do? Nothing easier than that with
+  `Wallaby.Query.compile/1` - it takes a query and returns you the css or xpath
+  query it will use:
+
+  ```
+  iex> Wallaby.Query.compile Wallaby.Query.text("my text")
+  {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
+  ```
+
+  So, whenever you're not sure whatever a specific query will do just compile
+  it to get all the details!
   """
   alias __MODULE__
   alias Wallaby.Query.XPath
@@ -99,6 +113,9 @@ defmodule Wallaby.Query do
   @type compiled :: {:xpath | :css, String.t}
 
 
+  @doc """
+  Literally queries for the css selector you provide.
+  """
   def css(selector, opts \\ []) do
     %Query{
       method: :css,
@@ -107,6 +124,9 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Literally queries for the xpath selector you provide.
+  """
   def xpath(selector, opts \\ []) do
     %Query{
       method: :xpath,
@@ -115,6 +135,9 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Checks if the provided text is contained anywhere.
+  """
   def text(selector, opts \\ []) do
     %Query{
       method: :text,
@@ -123,6 +146,9 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  See `Wallaby.Query.fillable_field/2`.
+  """
   def text_field(selector, opts \\ []) do
     %Query{
       method: :fillable_field,
@@ -132,6 +158,11 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for a text input field where the provided selector is the id, name or
+  placeholder of the text field itself or alternatively the id or the text of
+  the label.
+  """
   def fillable_field(selector, opts \\ []) do
     %Query{
       method: :fillable_field,
@@ -141,6 +172,11 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for a radio button where the provided selector is the id, name or
+  placeholder of the radio button itself or alternatively the id or the text of
+  the label.
+  """
   def radio_button(selector, opts \\ []) do
     %Query{
       method: :radio_button,
@@ -150,6 +186,11 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for a checkbox where the provided selector is the id, name or
+  placeholder of the checkbox itself or alternatively the id or the text of
+  the label.
+  """
   def checkbox(selector, opts \\ []) do
     %Query{
       method: :checkbox,
@@ -159,6 +200,10 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for a select box where the provided selector is the id or name of the
+  select box itself or alternatively the id or the text of the label.
+  """
   def select(selector, opts \\ []) do
     %Query{
       method: :select,
@@ -168,6 +213,9 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for an option with the given text appears.
+  """
   def option(selector, opts \\ []) do
     %Query{
       method: :option,
@@ -177,6 +225,11 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks for a button (literal button or input type button, submit, image or
+  reset) where the provided selector is the id, name, value, alt or title of the
+  button.
+  """
   def button(selector, opts \\ []) do
     %Query{
       method: :button,
@@ -186,6 +239,10 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looks a link where the selector is the id, link text, title of the link itself
+  or the alt of an image child node.
+  """
   def link(selector, opts \\ []) do
     %Query{
       method: :link,
@@ -195,6 +252,10 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Looke for a file input where the selector is the id or name of the file input
+  itself or the id or text of the label.
+  """
   def file_field(selector, opts \\ []) do
     %Query{
       method: :file_field,
@@ -217,6 +278,18 @@ defmodule Wallaby.Query do
   end
 
   @spec compile(t) :: compiled
+  @doc """
+  Takes a query and compiles it into either css or xpath, which are the queries
+  that will finally be issued to the driver.
+
+  ```
+  iex> Wallaby.Query.compile Wallaby.Query.text("my text")
+  {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
+  iex> Wallaby.Query.compile Wallaby.Query.css("#some-id")
+  {:css, "#some-id"}
+
+  ```
+  """
   def compile(%{method: :css, selector: selector}), do: {:css, selector}
   def compile(%{method: :xpath, selector: selector}), do: {:xpath, selector}
   def compile(%{method: :link, selector: selector}), do: {:xpath, XPath.link(selector)}

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -57,14 +57,12 @@ defmodule Wallaby.Query do
 
   ## What does my query do?
 
-  Wanna check out what exactly your query will do? Nothing easier than that with
-  `Wallaby.Query.compile/1` - it takes a query and returns you the css or xpath
-  query it will use:
+  Wanna check out what exactly your query will do? Look no further than
+  `Wallaby.Query.compile/1` - it takes a query and returns the css or xpath
+  query that will be sent to the driver:
 
-  ```
-  iex> Wallaby.Query.compile Wallaby.Query.text("my text")
-  {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
-  ```
+      iex> Wallaby.Query.compile Wallaby.Query.text("my text")
+      {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
 
   So, whenever you're not sure whatever a specific query will do just compile
   it to get all the details!
@@ -214,7 +212,7 @@ defmodule Wallaby.Query do
   end
 
   @doc """
-  Looks for an option with the given text appears.
+  Looks for an option that contains the given text.
   """
   def option(selector, opts \\ []) do
     %Query{
@@ -240,8 +238,8 @@ defmodule Wallaby.Query do
   end
 
   @doc """
-  Looks a link where the selector is the id, link text, title of the link itself
-  or the alt of an image child node.
+  Looks for a link where the selector is the id, link text, title of the link
+  itself or the alt of an image child node.
   """
   def link(selector, opts \\ []) do
     %Query{
@@ -253,7 +251,7 @@ defmodule Wallaby.Query do
   end
 
   @doc """
-  Looke for a file input where the selector is the id or name of the file input
+  Looks for a file input where the selector is the id or name of the file input
   itself or the id or text of the label.
   """
   def file_field(selector, opts \\ []) do
@@ -279,16 +277,12 @@ defmodule Wallaby.Query do
 
   @spec compile(t) :: compiled
   @doc """
-  Takes a query and compiles it into either css or xpath, which are the queries
-  that will finally be issued to the driver.
+  Compiles a query into css or xpath so its ready to be sent to the driver
 
-  ```
-  iex> Wallaby.Query.compile Wallaby.Query.text("my text")
-  {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
-  iex> Wallaby.Query.compile Wallaby.Query.css("#some-id")
-  {:css, "#some-id"}
-
-  ```
+      iex> Wallaby.Query.compile Wallaby.Query.text("my text")
+      {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
+      iex> Wallaby.Query.compile Wallaby.Query.css("#some-id")
+      {:css, "#some-id"}
   """
   def compile(%{method: :css, selector: selector}), do: {:css, selector}
   def compile(%{method: :xpath, selector: selector}), do: {:xpath, selector}

--- a/test/wallaby/query_test.exs
+++ b/test/wallaby/query_test.exs
@@ -1,5 +1,6 @@
 defmodule Wallaby.QueryTest do
   use ExUnit.Case, async: true
+  doctest Wallaby.Query
 
   alias Wallaby.Query
 


### PR DESCRIPTION
Feedback very welcome! This is stuff I'd often look up myself by compiling queries while working with wallaby :)

Honestly: I'm not the best at xpath ;P So theoretically I might have gotten some of those wrong.

Some ideas/thoughts:
* Not sure if the attributes should be like they are atm e.g. id or if it should be in ` e.g. `id`
* I had thought about including a doc test that shows a compiled query (I just looked at those when I wrote these) - might help for people, might be too much - my biggest fear is that we'd basically have to adjust these tests every time we change how something is compiled which sounds like a medium big manual churn.

Doc writing style etc. can gladly be commented on, nut sure if all the words are used ideally :)
