### PR TITLE
Allow specifying a name for the screenshot file

### DIFF
--- a/integration_test/cases/browser/screenshot_test.exs
+++ b/integration_test/cases/browser/screenshot_test.exs
@@ -56,6 +56,20 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     File.rm_rf! "#{File.cwd!}/shots"
   end
 
+  test "users can specify the screenshot name", %{page: page} do
+    Application.put_env(:wallaby, :screenshot_dir, "shots")
+
+    [screenshot_path] =
+      page
+      |> take_screenshot(%{name: "some_page"})
+      |> Map.get(:screenshots)
+
+    assert screenshot_path == "shots/some_page.png"
+
+    Application.put_env(:wallaby, :screenshot_dir, nil)
+    File.rm_rf! "#{File.cwd!}/shots"
+  end
+
   test "automatically taking screenshots on failure", %{page: page} do
     assert_raise Wallaby.QueryError, fn ->
       find(page, css(".some-selector"))

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -199,15 +199,17 @@ defmodule Wallaby.Browser do
   Takes a screenshot of the current window.
   Screenshots are saved to a "screenshots" directory in the same directory the
   tests are run in.
+
+  Pass %{name: "some_name"} to specify the file name. Defaults to a timestamp.
   """
   @spec take_screenshot(parent) :: parent
 
-  def take_screenshot(%{driver: driver} = screenshotable) do
+  def take_screenshot(%{driver: driver} = screenshotable, opts \\ %{}) do
     image_data =
       screenshotable
       |> driver.take_screenshot
 
-    path = path_for_screenshot()
+    path = path_for_screenshot(%{name: opts[:name]})
     File.write! path, image_data
 
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
@@ -938,9 +940,13 @@ defmodule Wallaby.Browser do
     Application.get_env(:wallaby, :base_url) || ""
   end
 
-  defp path_for_screenshot do
+  defp path_for_screenshot(%{name: nil}) do
+    path_for_screenshot(%{name: "#{:erlang.system_time}"})
+  end
+
+  defp path_for_screenshot(%{name: name}) when is_binary(name) do
     File.mkdir_p!(screenshot_dir())
-    "#{screenshot_dir()}/#{:erlang.system_time}.png"
+    "#{screenshot_dir()}/#{name}.png"
   end
 
   defp screenshot_dir do


### PR DESCRIPTION
I see that there was a some effort to [automatically name screenshots based on the module and test](https://github.com/keathley/wallaby/pull/156), but it's been quiet there for about 7 months.

This PR is simpler: just let users specify the filename, and default to a timestamp as we do now.