### PR TITLE
Make deps examples consistent and test-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Add Wallaby to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:wallaby, "~> 0.19.1"}]
+  [{:wallaby, "~> 0.19.1", only: :test}]
 end
 ```
 
@@ -166,7 +166,7 @@ You will also want to add `phoenix_ecto` as a dependency to `MyWebApp`:
 
 def deps do
   [
-    {:wallaby, "~> 0.17.0", only: :test},
+    {:wallaby, "~> 0.19.1", only: :test},
     {:phoenix_ecto, "~> 3.0", only: :test}
   ]
 end


### PR DESCRIPTION
`only: [:test]` is important; otherwise staging or prod may blow up if phantomjs isn't installed