### PR TITLE
Run credo in strict mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 script:
   - mix coveralls.travis
   - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
-  - mix credo -- strict
+  - mix credo --strict
 
 after_script:
   - mix deps.get --only docs


### PR DESCRIPTION
After reviewing the builds, I realized that credo is not running in strict mode. You can see this in the following command output:

    Analysis took 1.7 seconds (0.07s to load, 1.6s running checks)

    520 mods/funs, found 1 software design suggestion.

    Showing priority issues: ↑ ↗ →  (use `--strict` to show all issues,
    `--help` for options).

Instead of `mix credo -- strict` it should be `mix credo --strict`.