### PR TITLE
Support Arch Linux chromedriver

### DIFF
--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -4,7 +4,7 @@ defmodule Wallaby.Experimental.Chrome do
 
   @behaviour Wallaby.Driver
 
-  @chromedriver_version_regex ~r/^ChromeDriver 2\.(\d+).(\d+) \(.*\)/
+  @chromedriver_version_regex ~r/^ChromeDriver 2\.(\d+)/
 
   alias Wallaby.{Session, DependencyException, Metadata}
   alias Wallaby.Experimental.Chrome.{Chromedriver}


### PR DESCRIPTION
Arch Linux gives a different output when checking for the chromedriver version.

for example:

* On Arch
```
$ chromedriver --version
ChromeDriver 2.30
```

* On Mac:
```
$ chromedriver --version
ChromeDriver 2.33.506106 (8a06c39c4582fbfbab6966dbb1c38a9173bfb1a2)
```

So Arch misses the additional version hashes.

As these are not being used at all in the check for the version it should be safe to ignore that part.
