### PR TITLE
Fixes zombie phantomjs

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,6 @@
 use Mix.Config
 
 # Prevents timeouts in ExUnit
-config :wallaby, hackney_options: [timeout: 10_000, recv_timeout: 10_000]
+config :wallaby,
+  hackney_options: [timeout: 10_000, recv_timeout: 10_000],
+  tmp_dir_prefix: "wallaby_test"

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -30,6 +30,7 @@ defmodule Wallaby do
     end
 
     children = [
+      supervisor(Wallaby.Driver.ProcessWorkspace.ServerSupervisor, []),
       supervisor(driver(), [[name: Wallaby.Driver.Supervisor]]),
       worker(Wallaby.SessionStore, []),
     ]

--- a/lib/wallaby/driver/process_workspace.ex
+++ b/lib/wallaby/driver/process_workspace.ex
@@ -1,0 +1,24 @@
+defmodule Wallaby.Driver.ProcessWorkspace do
+  @moduledoc false
+
+  alias Wallaby.Driver.ProcessWorkspace.ServerSupervisor
+  alias Wallaby.Driver.TemporaryPath
+
+  # Creates a temporary workspace for a process that will
+  # be cleaned up after the process goes down.
+  @spec create(pid, String.t) :: {:ok, String.t}
+  def create(process_pid, workspace_path \\ generate_workspace_path()) do
+    {:ok, _} = ServerSupervisor.start_server(process_pid, workspace_path)
+    {:ok, workspace_path}
+  end
+
+  defp generate_workspace_path do
+    System.tmp_dir!
+    |> Path.join(tmp_dir_prefix())
+    |> TemporaryPath.generate()
+  end
+
+  defp tmp_dir_prefix do
+    Application.get_env(:wallaby, :tmp_dir_prefix, "")
+  end
+end

--- a/lib/wallaby/driver/process_workspace/server.ex
+++ b/lib/wallaby/driver/process_workspace/server.ex
@@ -1,0 +1,32 @@
+defmodule Wallaby.Driver.ProcessWorkspace.Server do
+  @moduledoc false
+
+  use GenServer
+
+  @spec start_link(pid, String.t) :: GenServer.on_start
+  def start_link(process_pid, workspace_path) do
+    GenServer.start_link(__MODULE__, [process_pid, workspace_path])
+  end
+
+  @impl GenServer
+  def init([process_pid, workspace_path]) do
+    Process.flag(:trap_exit, true)
+    ref = Process.monitor(process_pid)
+    File.mkdir(workspace_path)
+
+    {:ok, %{ref: ref, workspace_path: workspace_path}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, _, _}, %{ref: ref, workspace_path: workspace_path} = state) do
+    File.rm_rf(workspace_path)
+    {:stop, :normal, state}
+  end
+  def handle_info(msg, state), do: super(msg, state)
+
+  @impl GenServer
+  def terminate(:shutdown, %{workspace_path: workspace_path}) do
+    File.rm_rf(workspace_path)
+  end
+  def terminate(reason, state), do: super(reason, state)
+end

--- a/lib/wallaby/driver/process_workspace/server_supervisor.ex
+++ b/lib/wallaby/driver/process_workspace/server_supervisor.ex
@@ -1,0 +1,24 @@
+defmodule Wallaby.Driver.ProcessWorkspace.ServerSupervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias Wallaby.Driver.ProcessWorkspace.Server
+
+  @spec start_link :: Supervisor.on_start
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @spec start_server(pid, String.t) :: Supervisor.on_start_child
+  def start_server(process_pid, workspace_path) do
+    Supervisor.start_child(__MODULE__, [process_pid, workspace_path])
+  end
+
+  @impl Supervisor
+  def init([]) do
+    children = [worker(Server, [], restart: :transient)]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -3,7 +3,10 @@ defmodule Wallaby.Phantom.Server do
   use GenServer
 
   alias Wallaby.Driver.ExternalCommand
+  alias Wallaby.Driver.ProcessWorkspace
   alias Wallaby.Phantom.Server.ServerState
+
+  @type os_pid :: non_neg_integer
 
   @external_resource "priv/run_phantom.sh"
   @run_phantom_script_contents File.read! "priv/run_phantom.sh"
@@ -20,6 +23,16 @@ defmodule Wallaby.Phantom.Server do
     GenServer.call(server, :get_base_url, :infinity)
   end
 
+  @spec get_wrapper_os_pid(pid) :: os_pid
+  def get_wrapper_os_pid(server) do
+    GenServer.call(server, :get_wrapper_os_pid, :infinity)
+  end
+
+  @spec get_os_pid(pid) :: os_pid
+  def get_os_pid(server) do
+    GenServer.call(server, :get_os_pid, :infinity)
+  end
+
   def get_local_storage_dir(server) do
     GenServer.call(server, :get_local_storage_dir, :infinity)
   end
@@ -29,37 +42,65 @@ defmodule Wallaby.Phantom.Server do
   end
 
   def init(_) do
+    {:ok, workspace_path} = ProcessWorkspace.create(self())
+
     state =
-      ServerState.new()
-      |> create_local_storage_dir()
+      workspace_path
+      |> ServerState.new()
+      |> setup_workspace()
       |> start_phantom()
 
     {:ok, state}
   end
 
+  @spec setup_workspace(ServerState.t) :: ServerState.t
+  defp setup_workspace(%ServerState{} = state) do
+    state
+    |> create_local_storage_dir()
+    |> write_wrapper_script()
+  end
+
+  @spec start_phantom(ServerState.t) :: ServerState.t
   defp start_phantom(%ServerState{} = state) do
-    phantom_port =
+    wrapper_script_port =
       state
       |> ServerState.external_command()
-      |> open_port_with_wrapper_script()
+      |> open_port_with_wrapper_script(state)
 
-    %ServerState{state | phantom_port: phantom_port}
+    %ServerState{state |
+      wrapper_script_port: wrapper_script_port,
+      wrapper_script_os_pid: os_pid_from_port(wrapper_script_port)
+    }
   end
 
   @spec create_local_storage_dir(ServerState.t) :: ServerState.t
   defp create_local_storage_dir(%ServerState{} = state) do
-    File.mkdir_p(state.local_storage_path)
+    state |> ServerState.local_storage_path |> File.mkdir_p!
     state
   end
 
-  def handle_info({_port, {:data, output}}, %ServerState{running: false} = state) do
-    if output =~ "running on port" do
-      state = %{state | running: true}
-      {:ok, base_url} = ServerState.fetch_base_url(state)
-      Enum.each state.awaiting_url, &GenServer.reply(&1, base_url)
-      {:noreply, %{state | awaiting_url: []}}
-    else
-      {:noreply, state}
+  @spec write_wrapper_script(ServerState.t) :: ServerState.t
+  defp write_wrapper_script(%ServerState{} = state) do
+    path = ServerState.wrapper_script_path(state)
+
+    File.write!(path, @run_phantom_script_contents)
+    File.chmod!(path, 0o755)
+
+    state
+  end
+
+  def handle_info({port, {:data, output}}, %ServerState{running: false, wrapper_script_port: port} = state) do
+    case analyze_output(output) do
+      :phantom_up ->
+        state = %{state | running: true}
+        {:ok, base_url} = ServerState.fetch_base_url(state)
+        Enum.each state.awaiting_url, &GenServer.reply(&1, base_url)
+        {:noreply, %{state | awaiting_url: []}}
+      {:os_pid, os_pid} ->
+        Enum.each state.awaiting_os_pid, &GenServer.reply(&1, os_pid)
+        {:noreply, %{state | phantom_os_pid: os_pid, awaiting_os_pid: []}}
+      _ ->
+        {:noreply, state}
     end
   end
 
@@ -81,35 +122,73 @@ defmodule Wallaby.Phantom.Server do
     end
   end
 
+  def handle_call(:get_wrapper_os_pid, _, %ServerState{wrapper_script_os_pid: wrapper_script_os_pid} = state) do
+    {:reply, wrapper_script_os_pid, state}
+  end
+
+  def handle_call(:get_os_pid, from, %ServerState{phantom_os_pid: phantom_os_pid} = state) do
+    if phantom_os_pid do
+      {:reply, phantom_os_pid, state}
+    else
+      awaiting_os_pid = [from | state.awaiting_os_pid]
+      {:noreply, %{state | awaiting_os_pid: awaiting_os_pid}}
+    end
+  end
+
   def handle_call(:get_local_storage_dir, _from, state) do
-    {:reply, state.local_storage_path, state}
+    {:reply, ServerState.local_storage_path(state), state}
   end
 
   def handle_call(:clear_local_storage, _from, state) do
-    result = File.rm_rf(state.local_storage_path)
+    result =
+      state |> ServerState.local_storage_path |> File.rm_rf
 
     {:reply, result, state}
   end
 
-  def terminate(_reason, state) do
-    File.rm_rf(state.local_storage_path)
+  def terminate(_reason, %ServerState{wrapper_script_port: wrapper_script_port, wrapper_script_os_pid: wrapper_script_os_pid}) do
+    Port.close(wrapper_script_port)
+    wait_for_stop(wrapper_script_os_pid)
   end
 
-  defp open_port_with_wrapper_script(%ExternalCommand{executable: executable, args: args}) do
-    # Starts phantomjs using the run_phantom.sh wrapper script so phantomjs will
-    # be shutdown when stdin closes and when the beam terminates unexpectedly.
-    # When running as an escript, priv/run_phantom.sh will not be present so we
-    # pipe the script contents into sh -s. Here is the basic command we are
-    # running below:
-    #
-    #   <wrapper_script_contents > | sh -s phantomjs --arg-1 --arg-2
-    #
+  defp wait_for_stop(os_pid) do
+    if os_process_running?(os_pid) do
+      Process.sleep(100)
+      wait_for_stop(os_pid)
+    end
+  end
 
-    args = ["-s", executable] ++ args
+  @spec os_process_running?(os_pid) :: boolean
+  def os_process_running?(os_pid) do
+    case System.cmd("kill", ["-0", to_string(os_pid)], stderr_to_stdout: true) do
+      {_, 0} -> true
+      _ -> false
+    end
+  end
 
-    port = Port.open({:spawn_executable, System.find_executable("sh")},
-            [:binary, :stream, :use_stdio, :exit_status, args: args])
-    Port.command(port, @run_phantom_script_contents)
-    port
+  @spec open_port_with_wrapper_script(ExternalCommand.t, ServerState.t) :: port
+  defp open_port_with_wrapper_script(%ExternalCommand{executable: executable, args: args}, %ServerState{} = state) do
+    Port.open({:spawn_executable, ServerState.wrapper_script_path(state)},
+      [:binary, :stream, :use_stdio, :exit_status, :stderr_to_stdout,
+        args: [executable] ++ args])
+  end
+
+  @spec os_pid_from_port(port) :: non_neg_integer
+  defp os_pid_from_port(port) do
+    %{os_pid: os_pid} = port |> Port.info |> Enum.into(%{})
+    os_pid
+  end
+
+  @spec analyze_output(String.t) :: :phantom_up | {:os_pid, os_pid} | :unknown
+  defp analyze_output(output) do
+    cond do
+      output =~ "running on port" ->
+        :phantom_up
+      result = Regex.run(~r{PID: (\d+)}, output) ->
+        [_, os_pid] = result
+        {:os_pid, String.to_integer(os_pid)}
+      true ->
+        :unknown
+    end
   end
 end

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -2,17 +2,18 @@ defmodule Wallaby.Phantom.Server do
   @moduledoc false
   use GenServer
 
-  alias Wallaby.Driver.ExternalCommand
   alias Wallaby.Driver.ProcessWorkspace
   alias Wallaby.Phantom.Server.ServerState
+  alias Wallaby.Phantom.Server.StartTask
 
   @type os_pid :: non_neg_integer
 
-  @external_resource "priv/run_phantom.sh"
-  @run_phantom_script_contents File.read! "priv/run_phantom.sh"
+  @type start_link_opt ::
+    {:phantom_path, String.t}
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [])
+  @spec start_link([start_link_opt]) :: GenServer.on_start
+  def start_link(args \\ []) do
+    GenServer.start_link(__MODULE__, args)
   end
 
   def stop(server) do
@@ -20,119 +21,50 @@ defmodule Wallaby.Phantom.Server do
   end
 
   def get_base_url(server) do
-    GenServer.call(server, :get_base_url, :infinity)
+    GenServer.call(server, :get_base_url)
   end
 
   @spec get_wrapper_os_pid(pid) :: os_pid
   def get_wrapper_os_pid(server) do
-    GenServer.call(server, :get_wrapper_os_pid, :infinity)
+    GenServer.call(server, :get_wrapper_os_pid)
   end
 
   @spec get_os_pid(pid) :: os_pid
   def get_os_pid(server) do
-    GenServer.call(server, :get_os_pid, :infinity)
+    GenServer.call(server, :get_os_pid)
   end
 
   def get_local_storage_dir(server) do
-    GenServer.call(server, :get_local_storage_dir, :infinity)
+    GenServer.call(server, :get_local_storage_dir)
   end
 
   def clear_local_storage(server) do
-    GenServer.call(server, :clear_local_storage, :infinity)
+    GenServer.call(server, :clear_local_storage)
   end
 
-  def init(_) do
+  @impl GenServer
+  def init(args) do
     {:ok, workspace_path} = ProcessWorkspace.create(self())
 
-    state =
-      workspace_path
-      |> ServerState.new()
-      |> setup_workspace()
-      |> start_phantom()
-
-    {:ok, state}
-  end
-
-  @spec setup_workspace(ServerState.t) :: ServerState.t
-  defp setup_workspace(%ServerState{} = state) do
-    state
-    |> create_local_storage_dir()
-    |> write_wrapper_script()
-  end
-
-  @spec start_phantom(ServerState.t) :: ServerState.t
-  defp start_phantom(%ServerState{} = state) do
-    wrapper_script_port =
-      state
-      |> ServerState.external_command()
-      |> open_port_with_wrapper_script(state)
-
-    %ServerState{state |
-      wrapper_script_port: wrapper_script_port,
-      wrapper_script_os_pid: os_pid_from_port(wrapper_script_port)
-    }
-  end
-
-  @spec create_local_storage_dir(ServerState.t) :: ServerState.t
-  defp create_local_storage_dir(%ServerState{} = state) do
-    state |> ServerState.local_storage_path |> File.mkdir_p!
-    state
-  end
-
-  @spec write_wrapper_script(ServerState.t) :: ServerState.t
-  defp write_wrapper_script(%ServerState{} = state) do
-    path = ServerState.wrapper_script_path(state)
-
-    File.write!(path, @run_phantom_script_contents)
-    File.chmod!(path, 0o755)
-
-    state
-  end
-
-  def handle_info({port, {:data, output}}, %ServerState{running: false, wrapper_script_port: port} = state) do
-    case analyze_output(output) do
-      :phantom_up ->
-        state = %{state | running: true}
-        {:ok, base_url} = ServerState.fetch_base_url(state)
-        Enum.each state.awaiting_url, &GenServer.reply(&1, base_url)
-        {:noreply, %{state | awaiting_url: []}}
-      {:os_pid, os_pid} ->
-        Enum.each state.awaiting_os_pid, &GenServer.reply(&1, os_pid)
-        {:noreply, %{state | phantom_os_pid: os_pid, awaiting_os_pid: []}}
-      _ ->
-        {:noreply, state}
+    case workspace_path |> ServerState.new(args) |> start_phantom() do
+      {:ok, server_state} ->
+        {:ok, server_state}
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 
-  def handle_info({_port, {:exit_status, status}}, state) do
-    {:stop, {:exit_status, status}, %{state | running: false}}
-  end
-
-  def handle_info(_msg, state) do
-    {:noreply, state}
-  end
-
-  def handle_call(:get_base_url, from, state) do
-    case ServerState.fetch_base_url(state) do
-      {:ok, url} ->
-        {:reply, url, state}
-      {:error, :not_running} ->
-        awaiting_url = [from | state.awaiting_url]
-        {:noreply, %{state | awaiting_url: awaiting_url}}
-    end
+  @impl GenServer
+  def handle_call(:get_base_url, _, state) do
+    {:reply, ServerState.base_url(state), state}
   end
 
   def handle_call(:get_wrapper_os_pid, _, %ServerState{wrapper_script_os_pid: wrapper_script_os_pid} = state) do
     {:reply, wrapper_script_os_pid, state}
   end
 
-  def handle_call(:get_os_pid, from, %ServerState{phantom_os_pid: phantom_os_pid} = state) do
-    if phantom_os_pid do
-      {:reply, phantom_os_pid, state}
-    else
-      awaiting_os_pid = [from | state.awaiting_os_pid]
-      {:noreply, %{state | awaiting_os_pid: awaiting_os_pid}}
-    end
+  def handle_call(:get_os_pid, _, %ServerState{phantom_os_pid: phantom_os_pid} = state) do
+    {:reply, phantom_os_pid, state}
   end
 
   def handle_call(:get_local_storage_dir, _from, state) do
@@ -146,11 +78,28 @@ defmodule Wallaby.Phantom.Server do
     {:reply, result, state}
   end
 
+  @impl GenServer
+  def handle_info({port, {:data, _output}}, %ServerState{wrapper_script_port: port} = state) do
+    {:noreply, state}
+  end
+  def handle_info({port, {:exit_status, status}}, %ServerState{wrapper_script_port: port} = state) do
+    {:stop, {:exit_status, status}, state}
+  end
+  def handle_info(msg, state), do: super(msg, state)
+
+  @impl GenServer
   def terminate(_reason, %ServerState{wrapper_script_port: wrapper_script_port, wrapper_script_os_pid: wrapper_script_os_pid}) do
     Port.close(wrapper_script_port)
     wait_for_stop(wrapper_script_os_pid)
   end
 
+  @spec start_phantom(ServerState.t) ::
+    {:ok, ServerState.t} | {:error, StartTask.error_reason}
+  defp start_phantom(%ServerState{} = state) do
+    state |> StartTask.async() |> Task.await()
+  end
+
+  @spec wait_for_stop(os_pid) :: nil
   defp wait_for_stop(os_pid) do
     if os_process_running?(os_pid) do
       Process.sleep(100)
@@ -163,32 +112,6 @@ defmodule Wallaby.Phantom.Server do
     case System.cmd("kill", ["-0", to_string(os_pid)], stderr_to_stdout: true) do
       {_, 0} -> true
       _ -> false
-    end
-  end
-
-  @spec open_port_with_wrapper_script(ExternalCommand.t, ServerState.t) :: port
-  defp open_port_with_wrapper_script(%ExternalCommand{executable: executable, args: args}, %ServerState{} = state) do
-    Port.open({:spawn_executable, ServerState.wrapper_script_path(state)},
-      [:binary, :stream, :use_stdio, :exit_status, :stderr_to_stdout,
-        args: [executable] ++ args])
-  end
-
-  @spec os_pid_from_port(port) :: non_neg_integer
-  defp os_pid_from_port(port) do
-    %{os_pid: os_pid} = port |> Port.info |> Enum.into(%{})
-    os_pid
-  end
-
-  @spec analyze_output(String.t) :: :phantom_up | {:os_pid, os_pid} | :unknown
-  defp analyze_output(output) do
-    cond do
-      output =~ "running on port" ->
-        :phantom_up
-      result = Regex.run(~r{PID: (\d+)}, output) ->
-        [_, os_pid] = result
-        {:os_pid, String.to_integer(os_pid)}
-      true ->
-        :unknown
     end
   end
 end

--- a/lib/wallaby/phantom/server/server_state.ex
+++ b/lib/wallaby/phantom/server/server_state.ex
@@ -11,10 +11,8 @@ defmodule Wallaby.Phantom.Server.ServerState do
   @type t :: %__MODULE__{
     workspace_path: String.t,
     port_number: port_number,
-    running: boolean,
     phantom_path: String.t,
     phantom_args: [String.t],
-    awaiting_url: [pid],
     wrapper_script_port: port | nil,
     wrapper_script_os_pid: os_pid | nil,
     phantom_os_pid: os_pid | nil,
@@ -27,10 +25,7 @@ defmodule Wallaby.Phantom.Server.ServerState do
     :phantom_args,
     :wrapper_script_port,
     :wrapper_script_os_pid,
-    :phantom_os_pid,
-    running: false,
-    awaiting_os_pid: [],
-    awaiting_url: []]
+    :phantom_os_pid]
 
   @type workspace_path :: String.t
 
@@ -53,10 +48,9 @@ defmodule Wallaby.Phantom.Server.ServerState do
     }
   end
 
-  @spec fetch_base_url(t) :: {:ok, String.t} | {:error, :not_running}
-  def fetch_base_url(%__MODULE__{running: false}), do: {:error, :not_running}
-  def fetch_base_url(%__MODULE__{port_number: port_number}) do
-    {:ok, "http://localhost:#{port_number}/"}
+  @spec base_url(t) :: String.t
+  def base_url(%__MODULE__{port_number: port_number}) do
+    "http://localhost:#{port_number}/"
   end
 
   @spec external_command(t) :: ExternalCommand.t

--- a/lib/wallaby/phantom/server/server_state.ex
+++ b/lib/wallaby/phantom/server/server_state.ex
@@ -2,43 +2,49 @@ defmodule Wallaby.Phantom.Server.ServerState do
   @moduledoc false
 
   alias Wallaby.Driver.ExternalCommand
-  alias Wallaby.Driver.TemporaryPath
   alias Wallaby.Driver.Utils
 
   @type port_number :: 0..65_535
 
+  @type os_pid :: non_neg_integer
+
   @type t :: %__MODULE__{
+    workspace_path: String.t,
     port_number: port_number,
-    local_storage_path: String.t,
     running: boolean,
     phantom_path: String.t,
     phantom_args: [String.t],
     awaiting_url: [pid],
-    phantom_port: port | nil,
+    wrapper_script_port: port | nil,
+    wrapper_script_os_pid: os_pid | nil,
+    phantom_os_pid: os_pid | nil,
   }
 
   defstruct [
+    :workspace_path,
     :port_number,
-    :local_storage_path,
-    :phantom_port,
     :phantom_path,
     :phantom_args,
+    :wrapper_script_port,
+    :wrapper_script_os_pid,
+    :phantom_os_pid,
     running: false,
+    awaiting_os_pid: [],
     awaiting_url: []]
+
+  @type workspace_path :: String.t
 
   @type new_opt ::
     {:port_number, port_number} |
-    {:local_storage_path, String.t} |
     {:phantom_path, String.t} |
     {:phantom_args, [String.t] | String.t}
 
-  @spec new([new_opt]) :: t
-  def new(params \\ []) do
+  @spec new(workspace_path, [new_opt]) :: t
+  def new(workspace_path, params \\ []) do
     %__MODULE__{
+      workspace_path: workspace_path,
       port_number: Keyword.get_lazy(params, :port_number,
                                     &Utils.find_available_port/0),
-      local_storage_path: Keyword.get_lazy(params, :local_storage_path,
-                                    &TemporaryPath.generate/0),
       phantom_path: Keyword.get_lazy(params, :phantom_path,
                                     &Wallaby.phantomjs_path/0),
       phantom_args: params
@@ -59,9 +65,19 @@ defmodule Wallaby.Phantom.Server.ServerState do
       executable: state.phantom_path,
       args: [
         "--webdriver=#{state.port_number}",
-        "--local-storage-path=#{state.local_storage_path}",
+        "--local-storage-path=#{local_storage_path(state)}",
       ] ++ state.phantom_args
     }
+  end
+
+  @spec local_storage_path(t) :: String.t
+  def local_storage_path(%__MODULE__{workspace_path: workspace_path}) do
+    Path.join(workspace_path, "local_storage")
+  end
+
+  @spec wrapper_script_path(t) :: charlist
+  def wrapper_script_path(%__MODULE__{workspace_path: workspace_path}) do
+    workspace_path |> Path.join("wrapper") |> to_charlist
   end
 
   @spec phantom_args_from_env :: [String.t] | String.t

--- a/lib/wallaby/phantom/server/start_task.ex
+++ b/lib/wallaby/phantom/server/start_task.ex
@@ -1,0 +1,118 @@
+defmodule Wallaby.Phantom.Server.StartTask do
+  @moduledoc false
+
+  #
+  # Task used to completely start phantomjs during the
+  # Wallaby.Phantom.Server.init/1 callback. That way, when the init callback
+  # finishes, the server is ready to use.
+  #
+
+  alias Wallaby.Driver.ExternalCommand
+  alias Wallaby.Phantom.Server.ServerState
+
+  @type os_pid :: non_neg_integer
+  @type exit_code :: 0..255
+  @type error_reason :: {:crashed, exit_code}
+
+  @external_resource "priv/run_phantom.sh"
+  @run_phantom_script_contents File.read! "priv/run_phantom.sh"
+
+  def async(server_state) do
+    Task.async(__MODULE__, :run, [self(), server_state])
+  end
+
+  @doc false
+  @spec run(pid, ServerState.t) ::
+    {:ok, ServerState.t} | {:error, error_reason}
+  def run(server_pid, server_state) do
+    case server_state |> setup_workspace() |> start_phantom() |> loop() do
+      {:ok, server_state} ->
+        # Transfers control of port over to the calling process.
+        Port.connect(server_state.wrapper_script_port, server_pid)
+        {:ok, server_state}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec loop(ServerState.t) ::
+    {:ok, ServerState.t} | {:error, error_reason}
+  def loop(%ServerState{wrapper_script_port: port} = state) do
+    receive do
+      {^port, {:data, output}} ->
+        case analyze_output(output) do
+          :phantom_up ->
+            {:ok, state}
+          {:os_pid, os_pid} ->
+            loop(%{state | phantom_os_pid: os_pid})
+          _ ->
+            loop(state)
+        end
+      {^port, {:exit_status, status}} ->
+        {:error, {:crashed, status}}
+    end
+  end
+
+  @spec setup_workspace(ServerState.t) :: ServerState.t
+  defp setup_workspace(%ServerState{} = state) do
+    state
+    |> create_local_storage_dir()
+    |> write_wrapper_script()
+  end
+
+  @spec create_local_storage_dir(ServerState.t) :: ServerState.t
+  defp create_local_storage_dir(%ServerState{} = state) do
+    state |> ServerState.local_storage_path |> File.mkdir_p!
+    state
+  end
+
+  @spec write_wrapper_script(ServerState.t) :: ServerState.t
+  defp write_wrapper_script(%ServerState{} = state) do
+    path = ServerState.wrapper_script_path(state)
+
+    File.write!(path, @run_phantom_script_contents)
+    File.chmod!(path, 0o755)
+
+    state
+  end
+
+  @spec start_phantom(ServerState.t) :: ServerState.t
+  defp start_phantom(%ServerState{} = state) do
+    wrapper_script_port =
+      state
+      |> ServerState.external_command()
+      |> open_port_with_wrapper_script(state)
+
+    %ServerState{state |
+      wrapper_script_port: wrapper_script_port,
+      wrapper_script_os_pid: os_pid_from_port(wrapper_script_port)
+    }
+  end
+
+  @spec analyze_output(String.t) :: :phantom_up | {:os_pid, os_pid} | :unknown
+  defp analyze_output(output) do
+    cond do
+      output =~ "running on port" ->
+        :phantom_up
+      result = Regex.run(~r{PID: (\d+)}, output) ->
+        [_, os_pid] = result
+        {:os_pid, String.to_integer(os_pid)}
+      true ->
+        :unknown
+    end
+  end
+
+  @spec open_port_with_wrapper_script(ExternalCommand.t, ServerState.t) :: port
+  defp open_port_with_wrapper_script(%ExternalCommand{executable: executable, args: args}, %ServerState{} = state) do
+    Port.open({:spawn_executable, ServerState.wrapper_script_path(state)},
+      [:binary, :stream, :use_stdio, :exit_status, :stderr_to_stdout,
+        args: [executable] ++ args])
+  end
+
+  @spec os_pid_from_port(port) :: non_neg_integer
+  defp os_pid_from_port(port) do
+    %{os_pid: os_pid} = port |> Port.info |> Enum.into(%{})
+    os_pid
+  end
+end

--- a/priv/run_phantom.sh
+++ b/priv/run_phantom.sh
@@ -1,9 +1,68 @@
 #!/bin/sh
-"$@" &
-pid=$!
-$(
+
+#
+# Wrapper script to start an external program and terminate it when it either
+# receives a SIGINT, SIGHUP, or SIGTERM or when STDIN closes. This script also
+# waits until all child processes have exited before exiting, so when the script
+# ends, we can be sure all started programs have finished.
+#
+
+set -e
+
+create_pipe(){
+  local pipe=$(mktemp -u)
+  mkfifo -m 600 "$pipe"
+  echo $pipe
+}
+
+remove_pipe(){
+  rm -f $1
+}
+
+wait_for_stdin_close(){
   while read line ; do
     :
   done
-  kill -KILL $pid
-)
+}
+
+wait_for_pids_to_exit(){
+  pids="$@"
+
+  for pid in $pids; do
+    while kill -0 $pid 2>/dev/null; do
+      sleep 0.1
+    done
+  done
+}
+
+shutdown(){
+  local my_pid=$1
+  local program_pid=$2
+
+  children=$(ps xao pid,pgid | grep $my_pid | awk '{print $1}' | grep -v $my_pid)
+  kill $program_pid 2>/dev/null
+
+  wait_for_pids_to_exit $children
+  exit 0
+}
+
+# Start the program in a subshell so we can wait until it ends and then kill
+# this wrapper script. In order to communicate the pid up to the parent process
+# we need to use a fifo pipe.
+my_pid=$$
+pid_pipe=$(create_pipe)
+trap 'remove_pipe "$pid_pipe"' EXIT
+(
+  "$@" &
+  echo $! >> $pid_pipe
+  wait 2>/dev/null
+  kill $my_pid
+) &
+read program_pid < "$pid_pipe"
+echo "PID: $program_pid"
+trap 'shutdown $my_pid $program_pid' INT HUP TERM
+remove_pipe $pid_pipe
+
+# Start shutdown process if stdin is closed
+wait_for_stdin_close
+shutdown $my_pid $program_pid

--- a/test/wallaby/driver/process_workspace_test.exs
+++ b/test/wallaby/driver/process_workspace_test.exs
@@ -1,0 +1,65 @@
+defmodule Wallaby.Driver.ProcessWorkspaceTest do
+  use ExUnit.Case, async: true
+
+  alias Wallaby.Driver.ProcessWorkspace
+  alias Wallaby.Driver.TemporaryPath
+
+  defmodule TestServer do
+    use GenServer
+
+    def start_link, do: GenServer.start_link(__MODULE__, [])
+    def stop(pid), do: GenServer.stop(pid)
+
+    @impl GenServer
+    def init([]), do: {:ok, []}
+  end
+
+  describe "create/2" do
+    test "creates a workspace dir which is deleted after the process ends" do
+      {:ok, test_server} = TestServer.start_link()
+      {:ok, workspace_path} = ProcessWorkspace.create(test_server)
+
+      assert File.exists?(workspace_path)
+
+      TestServer.stop(test_server)
+      Process.sleep(100)
+
+      refute File.exists?(workspace_path)
+    end
+
+    test "when workspace already exists" do
+      workspace_path = gen_tmp_path()
+      File.mkdir(workspace_path)
+      {:ok, test_server} = TestServer.start_link()
+      {:ok, ^workspace_path} =
+        ProcessWorkspace.create(test_server, workspace_path)
+
+      assert File.exists?(workspace_path)
+
+      TestServer.stop(test_server)
+      Process.sleep(100)
+
+      refute File.exists?(workspace_path)
+    end
+
+    test "creates a workspace dir using tmp_dir_prefix setting" do
+      {:ok, test_server} = TestServer.start_link()
+      {:ok, workspace_path} = ProcessWorkspace.create(test_server)
+
+      expected_path_prefix =
+        Path.join(
+          System.tmp_dir!, Application.get_env(:wallaby, :tmp_dir_prefix, ""))
+
+      assert workspace_path =~ ~r(^#{expected_path_prefix})
+    end
+  end
+
+  defp gen_tmp_path do
+    base_dir =
+      Path.join(
+        System.tmp_dir!(),
+        Application.get_env(:wallaby, :tmp_dir_prefix, ""))
+
+    TemporaryPath.generate(base_dir)
+  end
+end

--- a/test/wallaby/phantom/server/server_state_test.exs
+++ b/test/wallaby/phantom/server/server_state_test.exs
@@ -14,7 +14,6 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
     test "creates a new server state that's not running" do
       assert %ServerState{
         workspace_path: "/tmp",
-        running: false
       } = ServerState.new("/tmp")
     end
 
@@ -46,17 +45,11 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
     end
   end
 
-  describe "fetch_base_url/1" do
-    test "when the server is running" do
-      state = [port_number: 8080] |> build_server_state() |> struct(running: true)
+  describe "base_url/1" do
+    test "returns the proper url" do
+      state = [port_number: 8080] |> build_server_state()
 
-      assert {:ok, "http://localhost:8080/"} = ServerState.fetch_base_url(state)
-    end
-
-    test "when the server is not running" do
-      state = [port_number: 8080] |> build_server_state() |> struct(running: false)
-
-      assert {:error, :not_running} = ServerState.fetch_base_url(state)
+      assert "http://localhost:8080/" = ServerState.base_url(state)
     end
   end
 


### PR DESCRIPTION
PR commit contains several backend changes to solve the zombie phantom issue (#224).

1. New `ProcessWorkspace` helper which creates a temporary folder that is available for the life of the given process. This folder is a great place for writing the process wrapper script, creating local storage folders, etc. This folder is automatically deleted when the attached process exits (previously, these folders weren't getting cleaned up). Also, by writing the wrapper script to a temporary place on the file system instead of running it from priv, we are still able to use this library with an escript.

2. Improved run_phantom.sh wrapper script. This script now handles shutting down when STDIN is closed, shuts down when it receives an `INT`, `HUP`, or `TERM` signal, and shuts down when the underlying program crashes. Since phantom spawns several child processes, this script also waits until all child processes have exited before it exits itself. This helps prevent Wallaby's `ProcessWorkspace` from deleting the wrapper script and other temporary files before a phantomjs instance has fully shut down.

3. New tests to ensure that the `Wallaby.Phantom.Server` process responds as we'd expect during shutdown and various crashes. I also made the wrapper script echo back the PID of the phantom process so we can kill the underlying phantom process during tests.

4. There was a slight race condition where we can get zombie processes if we shutdown the `Wallaby.Phantom.Server` process before it's had a chance to fully start (specifically if it hasn't gotten to the part of the wrapper script where we wait for STDIN to close). The second commit in this PR solves that problem by not allowing `Wallaby.Phantom.Server.init/1` to return until phantom has successfully started. This makes it so we don't have to store references to calls like `get_base_url` and then return the data once the server is started. It also makes it so once the server returns from `start_link`, it's ready to use and we don't have to call `get_base_url` to wait for the server to be up. The one drawback of this approach is that the pool takes longer to start up since it currently starts workers sequentially. If that speed is an issue maybe we can figure out how to do parallel startup at the pool level.

Please let me know what you think and if there are any other improvements you'd like to see. My next goal is to adapt this script to automatically start Selenium during our test suite.
