### PR TITLE
Normalize exception names

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -48,7 +48,7 @@
       #     {Credo.Check.Design.DuplicatedCode, false}
       #
       checks: [
-        {Credo.Check.Consistency.ExceptionNames, false},
+        {Credo.Check.Consistency.ExceptionNames},
         {Credo.Check.Consistency.LineEndings},
         {Credo.Check.Consistency.ParameterPatternMatching},
         {Credo.Check.Consistency.SpaceAroundOperators},

--- a/integration_test/cases/browser/assert_refute_has_test.exs
+++ b/integration_test/cases/browser/assert_refute_has_test.exs
@@ -1,6 +1,8 @@
 defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
   use Wallaby.Integration.SessionCase, async: true
 
+  alias Wallaby.ExpectationNotMetError
+
   @found_query Query.css(".user", count: :any)
   @not_found_query Query.css(".something-else")
   @wrong_exact_found_query Query.css(".user", count: 5)
@@ -14,7 +16,7 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
     end
 
     test "raises if the query is not found", %{session: session} do
-      assert_raise Wallaby.ExpectationNotMet, ~r/Expected.+ 1.*css.*\.something-else.*0/i, fn ->
+      assert_raise ExpectationNotMetError, ~r/Expected.+ 1.*css.*\.something-else.*0/i, fn ->
         session
         |> visit("nesting.html")
         |> assert_has(@not_found_query)
@@ -22,7 +24,7 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
     end
 
     test "mentions the count of found vs. expected elements", %{session: session} do
-      assert_raise Wallaby.ExpectationNotMet, ~r/Expected.+ 5.*css.*\.user.*6/i, fn ->
+      assert_raise ExpectationNotMetError, ~r/Expected.+ 5.*css.*\.user.*6/i, fn ->
         session
         |> visit("nesting.html")
         |> assert_has(@wrong_exact_found_query)
@@ -40,7 +42,7 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
     end
 
     test "raises if the query is found on the page", %{session: session} do
-      assert_raise Wallaby.ExpectationNotMet, ~r/Expected not.+any.*css.*\.user.*6/i, fn ->
+      assert_raise ExpectationNotMetError, ~r/Expected not.+any.*css.*\.user.*6/i, fn ->
         session
         |> visit("nesting.html")
         |> refute_has(@found_query)

--- a/integration_test/cases/browser/assert_text_test.exs
+++ b/integration_test/cases/browser/assert_text_test.exs
@@ -1,6 +1,8 @@
 defmodule Wallaby.Integration.Browser.AssertTextTest do
   use Wallaby.Integration.SessionCase, async: true
 
+  alias Wallaby.ExpectationNotMetError
+
   test "has_text?/2 waits for presence of text and returns a bool", %{session: session} do
     element =
     session
@@ -26,7 +28,7 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
       |> visit("wait.html")
       |> find(Query.css("#container"))
 
-    assert_raise Wallaby.ExpectationNotMet, "Text 'rain' was not found.", fn ->
+    assert_raise ExpectationNotMetError, "Text 'rain' was not found.", fn ->
       assert_text(element, "rain")
     end
   end

--- a/integration_test/cases/browser/cookies_test.exs
+++ b/integration_test/cases/browser/cookies_test.exs
@@ -1,6 +1,8 @@
 defmodule Wallaby.Integration.Browser.CookiesTest do
   use Wallaby.Integration.SessionCase, async: true
 
+  alias Wallaby.CookieError
+
   describe "cookies/1" do
     test "returns all of the cookies in the browser", %{session: session} do
       list =
@@ -27,7 +29,7 @@ defmodule Wallaby.Integration.Browser.CookiesTest do
     end
 
     test "without visiting a page first throws an error", %{session: session} do
-      assert_raise Wallaby.CookieException, fn ->
+      assert_raise CookieError, fn ->
         session
         |> Browser.set_cookie("other_cookie", "test")
       end

--- a/integration_test/cases/browser/stale_nodes_test.exs
+++ b/integration_test/cases/browser/stale_nodes_test.exs
@@ -1,6 +1,8 @@
 defmodule Wallaby.Integration.Browser.StaleElementsTest do
   use Wallaby.Integration.SessionCase, async: true
 
+  alias Wallaby.StaleReferenceError
+
   describe "when a DOM element becomes stale" do
     test "the query is retried", %{session: session} do
       element =
@@ -20,7 +22,7 @@ defmodule Wallaby.Integration.Browser.StaleElementsTest do
       session
       |> assert_has(Query.css("#removed-node", count: 0))
 
-      assert_raise Wallaby.StaleReferenceException, fn ->
+      assert_raise StaleReferenceError, fn ->
         Element.value(element)
       end
     end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -107,6 +107,7 @@ defmodule Wallaby.Browser do
   alias Wallaby.Query
   alias Wallaby.Query.ErrorMessage
   alias Wallaby.Session
+  alias Wallaby.ExpectationNotMetError
 
   @type t :: any()
 
@@ -581,7 +582,7 @@ defmodule Wallaby.Browser do
     |> assert_text(text)
   end
   def assert_text(parent, text) when is_binary(text) do
-    has_text?(parent, text) || raise Wallaby.ExpectationNotMet, "Text '#{text}' was not found."
+    has_text?(parent, text) || raise ExpectationNotMetError, "Text '#{text}' was not found."
   end
 
   @doc """
@@ -612,13 +613,13 @@ defmodule Wallaby.Browser do
           case error do
             {:error, {:not_found, results}} ->
               query = %Query{query | result: results}
-              raise Wallaby.ExpectationNotMet,
+              raise ExpectationNotMetError,
                     Query.ErrorMessage.message(query, :not_found)
             {:error, :invalid_selector} ->
               raise Wallaby.QueryError,
                 Query.ErrorMessage.message(query, :invalid_selector)
             _ ->
-              raise Wallaby.ExpectationNotMet,
+              raise Wallaby.ExpectationNotMetError,
                 "Wallaby has encountered an internal error: #{inspect error} with session: #{inspect parent}"
           end
       end
@@ -647,7 +648,7 @@ defmodule Wallaby.Browser do
         {:error, _not_found} ->
           parent
         {:ok, query} ->
-          raise Wallaby.ExpectationNotMet,
+          raise Wallaby.ExpectationNotMetError,
                 Query.ErrorMessage.message(query, :found)
       end
     end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -108,6 +108,7 @@ defmodule Wallaby.Browser do
   alias Wallaby.Query.ErrorMessage
   alias Wallaby.Session
   alias Wallaby.ExpectationNotMetError
+  alias Wallaby.NoBaseUrlError
 
   @type t :: any()
 
@@ -699,7 +700,7 @@ defmodule Wallaby.Browser do
 
     cond do
       uri.host == nil && String.length(base_url()) == 0 ->
-        raise Wallaby.NoBaseUrl, path
+        raise NoBaseUrlError, path
       uri.host ->
         driver.visit(session, path)
       true ->

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -104,11 +104,12 @@ defmodule Wallaby.Browser do
   """
 
   alias Wallaby.Element
+  alias Wallaby.ExpectationNotMetError
   alias Wallaby.Query
   alias Wallaby.Query.ErrorMessage
-  alias Wallaby.Session
-  alias Wallaby.ExpectationNotMetError
   alias Wallaby.NoBaseUrlError
+  alias Wallaby.Session
+  alias Wallaby.StaleReferenceError
 
   @type t :: any()
 
@@ -927,7 +928,7 @@ defmodule Wallaby.Browser do
            {:ok, %Query{query | result: elements}}
         end
       rescue
-        Wallaby.StaleReferenceException ->
+        StaleReferenceError ->
           {:error, :stale_reference}
       end
     end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -103,6 +103,7 @@ defmodule Wallaby.Browser do
   |> todo_was_created?
   """
 
+  alias Wallaby.CookieError
   alias Wallaby.Element
   alias Wallaby.ExpectationNotMetError
   alias Wallaby.Query
@@ -719,14 +720,14 @@ defmodule Wallaby.Browser do
 
   def set_cookie(%Session{driver: driver} = session, key, value) do
     if blank_page?(session) do
-      raise Wallaby.CookieException
+      raise CookieError
     end
 
     case driver.set_cookie(session, key, value) do
       {:ok, _list} ->
         session
       {:error, :invalid_cookie_domain} ->
-        raise Wallaby.CookieException
+        raise CookieError
     end
   end
 

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -25,6 +25,7 @@ defmodule Wallaby.Element do
   Unlike `Browser` the actions in `Element` do not retry if the element becomes stale. Instead an exception will be raised.
   """
 
+  alias Wallaby.InvalidSelectorError
   alias Wallaby.StaleReferenceError
 
   defstruct [:url, :session_url, :parent, :id, :driver, screenshots: []]
@@ -55,7 +56,7 @@ defmodule Wallaby.Element do
       {:error, :stale_reference} ->
         raise StaleReferenceError
       {:error, :invalid_selector} ->
-        raise Wallaby.InvalidSelector
+        raise InvalidSelectorError
     end
   end
 

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -25,6 +25,8 @@ defmodule Wallaby.Element do
   Unlike `Browser` the actions in `Element` do not retry if the element becomes stale. Instead an exception will be raised.
   """
 
+  alias Wallaby.StaleReferenceError
+
   defstruct [:url, :session_url, :parent, :id, :driver, screenshots: []]
 
   @type value :: String.t
@@ -51,7 +53,7 @@ defmodule Wallaby.Element do
       {:ok, _} ->
         element
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
       {:error, :invalid_selector} ->
         raise Wallaby.InvalidSelector
     end
@@ -81,7 +83,7 @@ defmodule Wallaby.Element do
       {:ok, _} ->
         element
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
       {:error, :obscured} ->
         if retry_count > 4 do
           raise Wallaby.ExpectationNotMetError, """
@@ -103,7 +105,7 @@ defmodule Wallaby.Element do
       {:ok, text} ->
         text
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
     end
   end
 
@@ -117,7 +119,7 @@ defmodule Wallaby.Element do
       {:ok, attribute} ->
         attribute
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
     end
   end
 
@@ -164,7 +166,7 @@ defmodule Wallaby.Element do
       {:ok, _} ->
         element
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
       error -> error
     end
   end
@@ -182,7 +184,7 @@ defmodule Wallaby.Element do
       {:ok, _} ->
         element
       {:error, :stale_reference} ->
-        raise Wallaby.StaleReferenceException
+        raise StaleReferenceError
       error -> error
     end
   end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -84,7 +84,7 @@ defmodule Wallaby.Element do
         raise Wallaby.StaleReferenceException
       {:error, :obscured} ->
         if retry_count > 4 do
-          raise Wallaby.ExpectationNotMet, """
+          raise Wallaby.ExpectationNotMetError, """
           The element you tried to click is obscured by another element.
           """
         else

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -63,7 +63,7 @@ defmodule Wallaby.StaleReferenceError do
   end
 end
 
-defmodule Wallaby.InvalidSelector do
+defmodule Wallaby.InvalidSelectorError do
   defexception [:message]
 
   def exception(_) do

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -10,7 +10,7 @@ defmodule Wallaby.ExpectationNotMetError do
   defexception [:message]
 end
 
-defmodule Wallaby.BadMetadata do
+defmodule Wallaby.BadMetadataError do
   defexception [:message]
 end
 

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -47,7 +47,7 @@ defmodule Wallaby.JSError do
   end
 end
 
-defmodule Wallaby.StaleReferenceException do
+defmodule Wallaby.StaleReferenceError do
   defexception [:message]
 
   def exception(_) do

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -71,7 +71,7 @@ defmodule Wallaby.InvalidSelectorError do
   end
 end
 
-defmodule Wallaby.CookieException do
+defmodule Wallaby.CookieError do
   defexception [:message]
 
   def exception(_) do

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -14,7 +14,7 @@ defmodule Wallaby.BadMetadataError do
   defexception [:message]
 end
 
-defmodule Wallaby.NoBaseUrl do
+defmodule Wallaby.NoBaseUrlError do
   defexception [:message]
 
   def exception(relative_path) do

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.QueryError do
   end
 end
 
-defmodule Wallaby.ExpectationNotMet do
+defmodule Wallaby.ExpectationNotMetError do
   defexception [:message]
 end
 

--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -87,7 +87,7 @@ defmodule Wallaby.CookieError do
   end
 end
 
-defmodule Wallaby.DependencyException do
+defmodule Wallaby.DependencyError do
   defexception [:message]
 
   def exception(msg) do

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Experimental.Chrome do
 
   @chromedriver_version_regex ~r/^ChromeDriver 2\.(\d+)/
 
-  alias Wallaby.{Session, DependencyException, Metadata}
+  alias Wallaby.{Session, DependencyError, Metadata}
   alias Wallaby.Experimental.Chrome.{Chromedriver}
   alias Wallaby.Experimental.Selenium.WebdriverClient
   import Wallaby.Driver.LogChecker
@@ -38,14 +38,14 @@ defmodule Wallaby.Experimental.Chrome do
         if version >= 30 do
           :ok
         else
-          exception = DependencyException.exception """
+          exception = DependencyError.exception """
           Looks like you're trying to run an older version of chromedriver. Wallaby needs at least
           chromedriver 2.30 to run correctly.
           """
           {:error, exception}
         end
       _ ->
-        exception = DependencyException.exception """
+        exception = DependencyError.exception """
         Wallaby can't find chromedriver. Make sure you have chromedriver installed
         and included in your path.
         """

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -45,7 +45,7 @@ defmodule Wallaby.Metadata do
     |> :erlang.binary_to_term
     |> case do
         {:v1, metadata} -> metadata
-        _               -> raise Wallaby.BadMetadata, message: "#{encoded_metadata} is not valid"
+        _               -> raise Wallaby.BadMetadataError, message: "#{encoded_metadata} is not valid"
       end
   end
 end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -34,7 +34,7 @@ defmodule Wallaby.Phantom do
   use Supervisor
 
   alias Wallaby.Phantom.Driver
-  alias Wallaby.DependencyException
+  alias Wallaby.DependencyError
 
   @behaviour Wallaby.Driver
 
@@ -54,7 +54,7 @@ defmodule Wallaby.Phantom do
       System.find_executable("phantomjs") ->
         :ok
       true ->
-        exception = DependencyException.exception """
+        exception = DependencyError.exception """
         Wallaby can't find phantomjs. Make sure you have phantomjs installed
         and included in your path, or that your `config :wallaby, :phantomjs`
         setting points to a valid phantomjs executable.

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -1,12 +1,17 @@
 defmodule Wallaby.Phantom.Driver do
   @moduledoc false
 
-  alias Wallaby.{Driver, Element, Session, Phantom, Metadata}
-  alias Wallaby.Helpers.KeyCodes
-  alias Wallaby.Phantom.Server
+  import Wallaby.HTTPClient
   import Wallaby.Driver.LogChecker
 
-  import Wallaby.HTTPClient
+  alias Wallaby.Driver
+  alias Wallaby.Element
+  alias Wallaby.Helpers.KeyCodes
+  alias Wallaby.Phantom
+  alias Wallaby.Phantom.Server
+  alias Wallaby.Metadata
+  alias Wallaby.Session
+  alias Wallaby.StaleReferenceError
 
   @type method :: :post | :get | :delete
   @type url :: String.t
@@ -208,7 +213,7 @@ defmodule Wallaby.Phantom.Driver do
           value
 
         {:error, :stale_reference} ->
-          raise Wallaby.StaleReferenceException
+          raise StaleReferenceError
       end
     end
   end

--- a/test/wallaby/browser_test.exs
+++ b/test/wallaby/browser_test.exs
@@ -4,6 +4,7 @@ defmodule Wallaby.BrowserTest do
   import Wallaby.SettingsTestHelpers
 
   alias Wallaby.Browser
+  alias Wallaby.NoBaseUrlError
   alias Wallaby.Session
 
   defmodule TestDriver do
@@ -91,7 +92,7 @@ defmodule Wallaby.BrowserTest do
     test "relative url when the base_url isn't configured" do
       Application.delete_env(:wallaby, :base_url)
 
-      assert_raise Wallaby.NoBaseUrl, fn ->
+      assert_raise NoBaseUrlError, fn ->
         session = session_for_driver(TestDriver)
         Browser.visit(session, "/form.html")
       end

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -1,7 +1,7 @@
 defmodule Wallaby.Phantom.DriverTest do
   use Wallaby.HttpClientCase, async: true
 
-  alias Wallaby.{Element, Phantom, Query, Session, StaleReferenceException}
+  alias Wallaby.{Element, Phantom, Query, Session, StaleReferenceError}
   alias Wallaby.Phantom.Driver
 
   @window_handle_id "bdc333b0-1989-11e7-a2c3-d1d2d92b0e58"
@@ -411,7 +411,7 @@ defmodule Wallaby.Phantom.DriverTest do
         end
       end
 
-      assert_raise StaleReferenceException, fn ->
+      assert_raise StaleReferenceError, fn ->
         Driver.displayed!(element)
       end
     end


### PR DESCRIPTION
This normalizes exception names so they end in `Error`, per the Elixir style guide: https://github.com/lexmag/elixir-style-guide#exception-naming. It also enables the credo exception name check to ensure all new exceptions are named properly.