### PR TITLE
Wallaby shouldn't be a runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Add Wallaby to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:wallaby, "~> 0.19.2", only: :test}]
+  [{:wallaby, "~> 0.19.2", [runtime: false, only: :test]}]
 end
 ```
 


### PR DESCRIPTION
Wallaby doesn't need to started with other runtime dependencies since we encourage folks to start it explicitly in the test helper.