### PR TITLE
Add helper assertion `refute_text`

### DIFF
--- a/integration_test/cases/browser/refute_text_test.exs
+++ b/integration_test/cases/browser/refute_text_test.exs
@@ -1,0 +1,30 @@
+defmodule Wallaby.Integration.Browser.RefuteTextTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  alias Wallaby.ExpectationNotMetError
+
+  test "refute_text/2 waits for presence of text and returns true if not found", %{session: session} do
+    element = session
+              |> visit("wait.html")
+              |> find(Query.css("#container"))
+
+    assert refute_text(element, "not-present")
+  end
+
+  test "refute_text/2 will raise an exception when the text is found", %{session: session} do
+    element = session
+              |> visit("wait.html")
+              |> find(Query.css("#container"))
+
+    assert_raise ExpectationNotMetError, "Text 'main' was found.", fn ->
+      refute_text(element, "main")
+    end
+  end
+
+  test "refute_text/2 works with sessions", %{session: session} do
+    session
+    |> Browser.visit("wait.html")
+
+    assert Browser.refute_text(session, "not-present")
+  end
+end

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -4,6 +4,7 @@ Code.require_file "../cases/browser/all_test.exs", __DIR__
 Code.require_file "../cases/browser/assert_css_test.exs", __DIR__
 Code.require_file "../cases/browser/assert_refute_has_test.exs", __DIR__
 Code.require_file "../cases/browser/assert_text_test.exs", __DIR__
+Code.require_file "../cases/browser/refute_text_test.exs", __DIR__
 Code.require_file "../cases/browser/attr_test.exs", __DIR__
 Code.require_file "../cases/browser/clear_test.exs", __DIR__
 Code.require_file "../cases/browser/click_button_test.exs", __DIR__

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -4,6 +4,7 @@ Code.require_file "cases/browser/all_test.exs", __DIR__
 Code.require_file "cases/browser/assert_css_test.exs", __DIR__
 Code.require_file "cases/browser/assert_refute_has_test.exs", __DIR__
 Code.require_file "cases/browser/assert_text_test.exs", __DIR__
+Code.require_file "cases/browser/refute_text_test.exs", __DIR__
 Code.require_file "cases/browser/attr_test.exs", __DIR__
 Code.require_file "cases/browser/clear_test.exs", __DIR__
 Code.require_file "cases/browser/click_button_test.exs", __DIR__

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -589,6 +589,21 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
+  Matches the Element's content with the provided text and raises if the text is found
+  """
+  @spec refute_text(Element.t, String.t) :: boolean()
+  @spec refute_text(parent, Query.t, String.t) :: boolean()
+
+  def refute_text(parent, query, text) when is_binary(text) do
+    parent
+    |> find(query)
+    |> refute_text(text)
+  end
+  def refute_text(parent, text) when is_binary(text) do
+    !has_text?(parent, text) || raise ExpectationNotMetError, "Text '#{text}' was found."
+  end
+
+  @doc """
   Checks if `query` is present within `parent` and raises if not found.
 
   Returns the given `parent` if the assertion is correct so that it is easily


### PR DESCRIPTION
The companion to `assert_text`, this would be a helpful assertion to have when you want to test that text is not on the page for security reasons, or assuring that some sort of transition has happened. 