### PR TITLE
Fixes zombie phantomjs processes

### DIFF
--- a/priv/run_phantom.sh
+++ b/priv/run_phantom.sh
@@ -9,6 +9,8 @@
 
 set -e
 
+script_status="running"
+
 create_pipe(){
   local pipe=$(mktemp -u)
   mkfifo -m 600 "$pipe"
@@ -39,10 +41,13 @@ shutdown(){
   local my_pid=$1
   local program_pid=$2
 
-  children=$(ps xao pid,pgid | grep $my_pid | awk '{print $1}' | grep -v $my_pid)
-  kill $program_pid 2>/dev/null
+  if [ $script_status = "running" ]; then
+    script_status="shutting down"
 
-  wait_for_pids_to_exit $children
+    # Kill this script's process group
+    kill -TERM $(($my_pid * -1)) 2>/dev/null
+  fi
+
   exit 0
 }
 


### PR DESCRIPTION
After running wallaby as part of a separate application, I confirmed we were still leaving around zombie phantom processes (see #224). It turns out if we kill the script's process group, it will kill all of the child processes as well. This appears to fix the zombie issue once and for all.

One thing to note, I kill the process group by using the negative value of the wrapper script's pid, instead of using `ps axo pid, pgid` to look up the process group id. This is because I was occasionally running into issues where the process group lookup wasn't returning a result, causing
more zombie processes. Hopefully this approach won't cause any issues.

I've tested this on OS X and ubuntu and don't see any processes being left alive. I'm definitely not a shell scripting master, so any ideas for improvement would be greatly appreciated.