### PR TITLE
Improves readability of file_test failures.

### DIFF
--- a/integration_test/cases/browser/file_test.exs
+++ b/integration_test/cases/browser/file_test.exs
@@ -16,21 +16,27 @@ defmodule Wallaby.Integration.Browser.FileTest do
       page
       |> attach_file(file_field("file_input"), path: "integration_test/support/fixtures/file.txt")
 
-      assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
+      find(page, css("#file_field"), fn (element) ->
+        assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
+      end)
     end
 
     test "by DOM ID", %{page: page} do
       page
       |> attach_file(file_field("file_field"), path: "integration_test/support/fixtures/file.txt")
 
-      assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
+      find(page, css("#file_field"), fn (element) ->
+        assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
+      end)
     end
 
     test "by label", %{page: page} do
       page
       |> attach_file(file_field("File"), path: "integration_test/support/fixtures/file.txt")
 
-      assert find(page, css("#file_field")) |> has_value?("C:\\fakepath\\file.txt")
+      find(page, css("#file_field"), fn (element) ->
+        assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
+      end)
     end
   end
 
@@ -38,7 +44,9 @@ defmodule Wallaby.Integration.Browser.FileTest do
     page
     |> attach_file(file_field("File"), path: "integration_test/support/fixtures/fool.txt")
 
-    assert find(page, css("#file_field")) |> has_value?("")
+    find(page, css("#file_field"), fn (element) ->
+      assert Wallaby.Element.value(element) == ""
+    end)
   end
 
   test "checks for labels without for attributes", %{page: page} do


### PR DESCRIPTION
Rather than a failed assertion reporting `Expected truthy, got false`,
it will instead output the values on the left and right hand side making
it easier to diagnose the problem. This isn't a big deal for these
specific tests, but will hopefully make life easier for anyone copying
them into their own project.