### PR TITLE
Allow changing user agent PhantomJS via user_agent opt

### DIFF
--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -177,10 +177,10 @@ defmodule Wallaby.Phantom do
   @doc ~S"""
   Use a user agent that is passed, otherwise default to the PhantomJS user agent.
   """
-  def user_agent(ua), do: ua
   def user_agent(nil) do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
   end
+  def user_agent(ua), do: ua
   def user_agent do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
   end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -174,7 +174,13 @@ defmodule Wallaby.Phantom do
   defdelegate log(session_or_element),                            to: Driver
   defdelegate parse_log(log),                                     to: Wallaby.Phantom.Logger
 
-  @doc false
+  @doc ~S"""
+  Use a user agent that is passed, otherwise default to the PhantomJS user agent.
+  """
+  def user_agent(ua), do: ua
+  def user_agent(nil) do
+    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
+  end
   def user_agent do
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
   end

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -27,7 +27,7 @@ defmodule Wallaby.Phantom.Driver do
   def create(server, opts) do
     base_url = Server.get_base_url(server)
     user_agent =
-      Phantom.user_agent
+      Phantom.user_agent(opts[:user_agent])
       |> Metadata.append(opts[:metadata])
 
     capabilities = Phantom.capabilities(


### PR DESCRIPTION
Not sure if this is the way to do it, or if it is already possible?

This allows you to do:
```
Wallaby.start_session(user_agent: "Foobar Baz")
```