### PR TITLE
Always use session url for screenshots

### DIFF
--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -233,7 +233,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   """
   @spec take_screenshot(Session.t) :: binary
   def take_screenshot(session) do
-    with {:ok, resp}   <- request(:get, "#{session.url}/screenshot"),
+    with {:ok, resp}   <- request(:get, "#{session.session_url}/screenshot"),
           {:ok, value}  <- Map.fetch(resp, "value"),
           decoded_value <- :base64.decode(value),
       do: decoded_value


### PR DESCRIPTION
We can pass elements or sessions to `take_screenshot`. But using an element url doesn't work in chromedriver. We need to always use the session url even if elements are being passed in.