### PR TITLE
Add support for chrome binary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,17 @@ config :wallaby,
   ]
 ```
 
+### Custom Chrome binary
+
+By default chromedriver will find chrome for you but if you want to test against a different version you may use this option to point to the other chrome binary.
+
+```elixir
+config :wallaby,
+  chrome: [
+    binary: "path/to/google/chrome"
+  ]
+```
+
 ### Selenium
 
 To run selenium you'll need to install selenium-server-standalone and geckodriver.

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -29,36 +29,44 @@ defmodule Wallaby.Experimental.Chrome do
     case System.find_executable("chromedriver") do
       chromedriver when not is_nil(chromedriver) ->
         {version, 0} = System.cmd("chromedriver", ["--version"])
+
         version =
           @chromedriver_version_regex
           |> Regex.run(version)
           |> Enum.at(1)
-          |> String.to_integer
+          |> String.to_integer()
 
         if version >= 30 do
           :ok
         else
-          exception = DependencyError.exception """
-          Looks like you're trying to run an older version of chromedriver. Wallaby needs at least
-          chromedriver 2.30 to run correctly.
-          """
+          exception =
+            DependencyError.exception("""
+            Looks like you're trying to run an older version of chromedriver. Wallaby needs at least
+            chromedriver 2.30 to run correctly.
+            """)
+
           {:error, exception}
         end
+
       _ ->
-        exception = DependencyError.exception """
-        Wallaby can't find chromedriver. Make sure you have chromedriver installed
-        and included in your path.
-        """
+        exception =
+          DependencyError.exception("""
+          Wallaby can't find chromedriver. Make sure you have chromedriver installed
+          and included in your path.
+          """)
+
         {:error, exception}
     end
   end
 
   def start_session(opts) do
     {:ok, base_url} = Chromedriver.base_url()
-    create_session_fn = Keyword.get(opts, :create_session_fn,
-                                    &WebdriverClient.create_session/2)
-    user_agent = user_agent()
-                 |> Metadata.append(opts[:metadata])
+    create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
+
+    user_agent =
+      user_agent()
+      |> Metadata.append(opts[:metadata])
+
     capabilities = capabilities(user_agent: user_agent)
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
@@ -69,7 +77,7 @@ defmodule Wallaby.Experimental.Chrome do
         url: base_url <> "session/#{id}",
         id: id,
         driver: __MODULE__,
-        server: Chromedriver,
+        server: Chromedriver
       }
 
       {:ok, session}
@@ -86,6 +94,7 @@ defmodule Wallaby.Experimental.Chrome do
     case current_url(session) do
       {:ok, url} ->
         url == "data:,"
+
       _ ->
         false
     end
@@ -110,13 +119,13 @@ defmodule Wallaby.Experimental.Chrome do
     end)
   end
 
-  defdelegate accept_alert(session, fun),         to: WebdriverClient
-  defdelegate dismiss_alert(session, fun),        to: WebdriverClient
-  defdelegate accept_confirm(session, fun),       to: WebdriverClient
-  defdelegate dismiss_confirm(session, fun),      to: WebdriverClient
+  defdelegate accept_alert(session, fun), to: WebdriverClient
+  defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  defdelegate accept_confirm(session, fun), to: WebdriverClient
+  defdelegate dismiss_confirm(session, fun), to: WebdriverClient
   defdelegate accept_prompt(session, input, fun), to: WebdriverClient
-  defdelegate dismiss_prompt(session, fun),       to: WebdriverClient
-  defdelegate parse_log(log),                     to: Wallaby.Experimental.Chrome.Logger
+  defdelegate dismiss_prompt(session, fun), to: WebdriverClient
+  defdelegate parse_log(log), to: Wallaby.Experimental.Chrome.Logger
 
   @doc false
   def cookies(session), do: delegate(:cookies, session)
@@ -156,20 +165,22 @@ defmodule Wallaby.Experimental.Chrome do
     end
 
     if check_logs do
-      check_logs! session_or_element, request_fn
+      check_logs!(session_or_element, request_fn)
     else
       request_fn.()
     end
   end
 
   @doc false
-  def find_elements(session_or_element, compiled_query),  do: delegate(:find_elements, session_or_element, [compiled_query])
+  def find_elements(session_or_element, compiled_query),
+    do: delegate(:find_elements, session_or_element, [compiled_query])
+
   @doc false
   def send_keys(session_or_element, keys), do: delegate(:send_keys, session_or_element, [keys])
   @doc false
   def take_screenshot(session_or_element), do: delegate(:take_screenshot, session_or_element)
   @doc false
-  defdelegate log(session_or_element),                            to: WebdriverClient
+  defdelegate log(session_or_element), to: WebdriverClient
 
   @doc false
   def user_agent do
@@ -198,9 +209,10 @@ defmodule Wallaby.Experimental.Chrome do
     }
   end
 
-  defp chrome_options(opts), do: %{
-      args: chrome_args(opts)
-    }
+  defp chrome_options(opts) do
+    %{args: chrome_args(opts)}
+    |> put_unless_nil(:binary, chrome_binary_option())
+  end
 
   defp chrome_args(opts) do
     default_chrome_args()
@@ -217,11 +229,17 @@ defmodule Wallaby.Experimental.Chrome do
     |> Keyword.get(:headless, true)
   end
 
+  defp chrome_binary_option do
+    :wallaby
+    |> Application.get_env(:chrome, [])
+    |> Keyword.get(:binary)
+  end
+
   def default_chrome_args do
     [
       "--no-sandbox",
       "window-size=1280,800",
-      "--disable-gpu",
+      "--disable-gpu"
     ]
   end
 
@@ -232,4 +250,7 @@ defmodule Wallaby.Experimental.Chrome do
       []
     end
   end
+
+  defp put_unless_nil(map, _key, nil), do: map
+  defp put_unless_nil(map, key, value), do: Map.put(map, key, value)
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"benchee": {:hex, :benchee, "0.9.0", "433d946b0e4755e186fe564568ead4f593b0d15337fcffa95ed7d5b8a6612670", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
+%{
+  "benchee": {:hex, :benchee, "0.9.0", "433d946b0e4755e186fe564568ead4f593b0d15337fcffa95ed7d5b8a6612670", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "benchee_html": {:hex, :benchee_html, "0.3.1", "4f784a567f2999e28d36c13356495f455fad4fb88c66a9c2db60ab2b60d11479", [:mix], [{:benchee, "~> 0.8", [hex: :benchee, repo: "hexpm", optional: false]}, {:benchee_json, ">= 0.3.1", [hex: :benchee_json, repo: "hexpm", optional: false]}], "hexpm"},
   "benchee_json": {:hex, :benchee_json, "0.3.1", "f1df8d92041cfd863d980ca40dcba1c852a705190e26cdd41732f76c6bd099d6", [:mix], [{:benchee, "~> 0.8", [hex: :benchee, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
@@ -6,7 +7,7 @@
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
@@ -26,4 +27,5 @@
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
Continued from https://github.com/keathley/wallaby/pull/309#discussion_r140837822 (PR from different fork).

Requests from previous PR
- [x] this is totally nitpicking and not sure if others agree, but I'd implement this using 2 methods and pattern matching on nil in the first clause :)
- [x] Can we change the wording of this to just "but if you want to test against a different version..."
- [x] Can this function be private? 
- [x] credo warning (required update to 0.8.10 due to https://github.com/rrrene/credo/issues/469)
- [ ] Switch to `config :wallaby, Wallaby.Experimental.Chrome` convention (going to leave for this PR as it's an existing convention on the project)
