### PR TITLE
Finish chromedriver support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes
   - sudo apt-get update
   - sudo apt-get install google-chrome-beta
+  - sudo apt-get --only-upgrade install google-chrome-stable
   - sudo apt-get install libstdc++6-4.7-dev
   - MIX_ENV=test mix compile --warnings-as-errors
   - if [ -z ${WALLABY_DRIVER} ]; then travis_wait mix dialyzer --plt; fi # only run dialyzer for the env without drivers

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_script:
   - sudo mv chromedriver /usr/local/bin
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes
   - sudo apt-get update
-  - sudo apt-get install google-chrome-beta
   - sudo apt-get --only-upgrade install google-chrome-stable
   - sudo apt-get install libstdc++6-4.7-dev
   - MIX_ENV=test mix compile --warnings-as-errors

--- a/integration_test/cases/browser/dialog_test.exs
+++ b/integration_test/cases/browser/dialog_test.exs
@@ -6,92 +6,6 @@ defmodule Wallaby.Integration.Browser.DialogTest do
     {:ok, %{page: page}}
   end
 
-  describe "accept_dialogs/1" do
-    test "accept window.alert", %{page: page} do
-      result =
-        page
-        |> accept_dialogs()
-        |> click(Query.link("Alert"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Alert accepted"
-    end
-
-    test "accept window.confirm", %{page: page} do
-      result =
-        page
-        |> accept_dialogs()
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Confirm returned true"
-    end
-
-    test "accept window.prompt", %{page: page} do
-      result =
-        page
-        |> accept_dialogs()
-        |> click(Query.link("Prompt"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Prompt returned default"
-    end
-
-    test "overrides dismiss_dialogs/1", %{page: page} do
-      result =
-        page
-        |> dismiss_dialogs()
-        |> accept_dialogs()
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Confirm returned true"
-    end
-  end
-
-  describe "dismiss_dialogs/1" do
-    test "dismiss window.alert", %{page: page} do
-      result =
-        page
-        |> dismiss_dialogs()
-        |> click(Query.link("Alert"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Alert accepted"
-    end
-
-    test "dismiss window.confirm", %{page: page} do
-      result =
-        page
-        |> dismiss_dialogs()
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Confirm returned false"
-    end
-
-    test "dismiss window.prompt", %{page: page} do
-      result =
-        page
-        |> dismiss_dialogs()
-        |> click(Query.link("Prompt"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Prompt returned null"
-    end
-
-    test "overrides accept_dialogs/1", %{page: page} do
-      result =
-        page
-        |> accept_dialogs()
-        |> dismiss_dialogs()
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Confirm returned false"
-    end
-  end
-
   describe "accept_alert/2" do
     test "accept window.alert and get message", %{page: page} do
       message = accept_alert page, fn(p) ->
@@ -118,20 +32,6 @@ defmodule Wallaby.Integration.Browser.DialogTest do
       assert message == "Are you sure?"
       assert result == "Confirm returned true"
     end
-
-    test "resets itself when no window.confirm was triggered", %{page: page} do
-      message =
-        page
-        |> dismiss_dialogs()
-        |> accept_confirm(fn(_) -> :noop end)
-      result =
-        page
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert message == nil
-      assert result == "Confirm returned false"
-    end
   end
 
   describe "dismiss_confirm/2" do
@@ -145,18 +45,6 @@ defmodule Wallaby.Integration.Browser.DialogTest do
         |> Element.text()
       assert message == "Are you sure?"
       assert result == "Confirm returned false"
-    end
-
-    test "resets itself when no window.confirm was triggered", %{page: page} do
-      page
-      |> accept_dialogs()
-      |> dismiss_confirm(fn(_) -> :noop end)
-      result =
-        page
-        |> click(Query.link("Confirm"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert result == "Confirm returned true"
     end
   end
 
@@ -186,20 +74,6 @@ defmodule Wallaby.Integration.Browser.DialogTest do
         accept_prompt(page, [with: :foo], fn(_) -> :noop end)
       end
     end
-
-    test "resets itself when no window.prompt was triggered", %{page: page} do
-      message =
-        page
-        |> dismiss_dialogs()
-        |> accept_prompt(fn(_) -> :noop end)
-      result =
-        page
-        |> click(Query.link("Prompt"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert message == nil
-      assert result == "Prompt returned null"
-    end
   end
 
   describe "accept_prompt/3" do
@@ -214,20 +88,6 @@ defmodule Wallaby.Integration.Browser.DialogTest do
       assert message == "What's your name?"
       assert result == "Prompt returned Wallaby"
     end
-
-    test "resets itself when no window.prompt was triggered", %{page: page} do
-      message =
-        page
-        |> dismiss_dialogs()
-        |> accept_prompt([with: "Wallaby"], fn(_) -> :noop end)
-      result =
-        page
-        |> click(Query.link("Prompt"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert message == nil
-      assert result == "Prompt returned null"
-    end
   end
 
   describe "dismiss_prompt/2" do
@@ -235,26 +95,14 @@ defmodule Wallaby.Integration.Browser.DialogTest do
       message = dismiss_prompt page, fn(p) ->
         click(p, Query.link("Prompt"))
       end
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "What's your name?"
       assert result == "Prompt returned null"
-    end
-
-    test "resets itself when no window.prompt was triggered", %{page: page} do
-      message =
-        page
-        |> accept_dialogs()
-        |> dismiss_prompt(fn(_) -> :noop end)
-      result =
-        page
-        |> click(Query.link("Prompt"))
-        |> find(Query.css("#result"))
-        |> Element.text()
-      assert message == nil
-      assert result == "Prompt returned default"
     end
   end
 end

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -1,32 +1,7 @@
-# Code.require_file "../tests.exs", __DIR__
-Code.require_file "../cases/browser_test.exs", __DIR__
-Code.require_file "../cases/browser/all_test.exs", __DIR__
-Code.require_file "../cases/browser/assert_css_test.exs", __DIR__
-Code.require_file "../cases/browser/assert_refute_has_test.exs", __DIR__
-Code.require_file "../cases/browser/assert_text_test.exs", __DIR__
-Code.require_file "../cases/browser/attr_test.exs", __DIR__
-Code.require_file "../cases/browser/clear_test.exs", __DIR__
-Code.require_file "../cases/browser/click_button_test.exs", __DIR__
-Code.require_file "../cases/browser/click_test.exs", __DIR__
-Code.require_file "../cases/browser/cookies_test.exs", __DIR__
-Code.require_file "../cases/browser/current_path_test.exs", __DIR__
-Code.require_file "../cases/browser/execute_script_test.exs", __DIR__
-Code.require_file "../cases/browser/fill_in_test.exs", __DIR__
-Code.require_file "../cases/browser/find_test.exs", __DIR__
-Code.require_file "../cases/browser/has_css_test.exs", __DIR__
-Code.require_file "../cases/browser/has_text_test.exs", __DIR__
-Code.require_file "../cases/browser/has_value_test.exs", __DIR__
-Code.require_file "../cases/browser/local_storage_test.exs", __DIR__
-Code.require_file "../cases/browser/navigation_test.exs", __DIR__
-Code.require_file "../cases/browser/page_source_test.exs", __DIR__
-Code.require_file "../cases/browser/select_test.exs", __DIR__
-Code.require_file "../cases/browser/set_value_test.exs", __DIR__
-Code.require_file "../cases/browser/send_text_test.exs", __DIR__
-Code.require_file "../cases/browser/stale_nodes_test.exs", __DIR__
-Code.require_file "../cases/browser/text_test.exs", __DIR__
-Code.require_file "../cases/browser/title_test.exs", __DIR__
-Code.require_file "../cases/browser/visible_test.exs", __DIR__
+Code.require_file "../tests.exs", __DIR__
+
+# Additional test cases supported by phantom
+Code.require_file "../cases/browser/dialog_test.exs", __DIR__
+Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
-Code.require_file "../cases/element/send_keys_test.exs", __DIR__
-Code.require_file "../cases/query_test.exs", __DIR__
-Code.require_file "../cases/wallaby_test.exs", __DIR__
+Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -473,6 +473,7 @@ defmodule Wallaby.Browser do
         case validate_html(parent, query) do
           {:ok, _} ->
             raise Wallaby.QueryError, ErrorMessage.message(query, :not_found)
+
           {:error, html_error} ->
             raise Wallaby.QueryError, ErrorMessage.message(query, html_error)
         end
@@ -733,22 +734,6 @@ defmodule Wallaby.Browser do
 
   defp blank_page?(%Session{driver: driver} = session) do
     driver.blank_page?(session)
-  end
-
-  @doc """
-  Accepts all subsequent JavaScript dialogs in the given session.
-  """
-  def accept_dialogs(%Session{driver: driver} = session) do
-    driver.accept_dialogs(session)
-    session
-  end
-
-  @doc """
-  Dismisses all subsequent JavaScript dialogs in the given session.
-  """
-  def dismiss_dialogs(%Session{driver: driver} = session) do
-    driver.dismiss_dialogs(session)
-    session
   end
 
   @doc """

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -31,11 +31,6 @@ defmodule Wallaby.Driver do
   @callback accept_confirm(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
 
   @doc """
-  Invoked to accept all open dialogs.
-  """
-  @callback accept_dialogs(Session.t) :: {:ok, String.t} | {:error, reason}
-
-  @doc """
   Invoked to accept one prompt triggered within `open_dialog_fn` and return the prompt message.
   """
   @callback accept_prompt(Session.t, String.t | nil, open_dialog_fn) ::
@@ -55,11 +50,6 @@ defmodule Wallaby.Driver do
   Invoked to get the current url of the browser's session.
   """
   @callback current_url(Session.t) :: {:ok, String.t} | {:error, reason}
-
-  @doc """
-  Invoked to dismiss all open dialogs.
-  """
-  @callback dismiss_dialogs(Session.t) :: {:ok, String.t} | {:error, reason}
 
   @doc """
   Invoked to dismiss one confirm triggered within `open_dialog_fn` and return the confirm message.

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -101,9 +101,6 @@ defmodule Wallaby.Experimental.Chrome do
     delegate(:set_window_size, session, [handle, width, height])
   end
 
-  def accept_dialogs(_session), do: {:error, :not_implemented}
-  def dismiss_dialogs(_session), do: {:error, :not_implemented}
-
   defp delegate(fun, element_or_session, args \\ []) do
     check_logs!(element_or_session, fn ->
       apply(WebdriverClient, fun, [element_or_session | args])

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -75,8 +75,6 @@ defmodule Wallaby.Experimental.Selenium do
   end
 
   # Dialog handling not supported yet
-  def accept_dialogs(_session), do: {:error, :not_implemented}
-  def dismiss_dialogs(_session), do: {:error, :not_implemented}
   def accept_alert(_session, _fun), do: {:error, :not_implemented}
   def dismiss_alert(_session, _fun), do: {:error, :not_implemented}
   def accept_confirm(_session, _fun), do: {:error, :not_implemented}

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -102,9 +102,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
       do: value
   end
 
-  def dismiss_prompt(session, _fun) do
-    with  {:ok, resp} <- request(:post, "#{session.url}/dismiss_alert"),
-      do: resp
+  def dismiss_prompt(session, fun) do
+    fun.(session)
+    with  {:ok, value} <- alert_text(session),
+          {:ok, _resp} <- request(:post, "#{session.url}/alert/dismiss"),
+      do: value
   end
 
   @doc """

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -235,7 +235,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   """
   @spec take_screenshot(Session.t) :: binary
   def take_screenshot(session) do
-    with {:ok, resp}   <- request(:get, "#{session.url}/screenshot"),
+    with {:ok, resp}   <- request(:get, "#{session.session_url}/screenshot"),
           {:ok, value}  <- Map.fetch(resp, "value"),
           decoded_value <- :base64.decode(value),
       do: decoded_value

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -233,7 +233,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Takes a screenshot.
   """
-  @spec take_screenshot(Session.t) :: binary
+  @spec take_screenshot(Session.t | Element.t) :: binary
   def take_screenshot(session) do
     with {:ok, resp}   <- request(:get, "#{session.session_url}/screenshot"),
           {:ok, value}  <- Map.fetch(resp, "value"),

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -73,10 +73,14 @@ defmodule Wallaby.HTTPClient do
         {:error, :stale_reference}
       %{"message" => "stale element reference" <> _} ->
         {:error, :stale_reference}
+      %{"message" => "invalid selector" <> _} ->
+        {:error, :invalid_selector}
       %{"class" => "org.openqa.selenium.InvalidSelectorException"} ->
         {:error, :invalid_selector}
       %{"class" => "org.openqa.selenium.InvalidElementStateException"} ->
         {:error, :invalid_selector}
+      %{"message" => "unexpected alert" <> _} ->
+        {:error, :unexpected_alert}
       _ ->
         {:ok, response}
     end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -116,8 +116,6 @@ defmodule Wallaby.Phantom do
   end
 
   @doc false
-  defdelegate accept_dialogs(session),                            to: Driver
-  @doc false
   defdelegate accept_alert(session, open_dialog_fn),              to: Driver
   @doc false
   defdelegate accept_confirm(session, open_dialog_fn),            to: Driver
@@ -129,8 +127,6 @@ defmodule Wallaby.Phantom do
   defdelegate current_path(session),                             to: Driver
   @doc false
   defdelegate current_url(session),                              to: Driver
-  @doc false
-  defdelegate dismiss_dialogs(session),                           to: Driver
   @doc false
   defdelegate dismiss_confirm(session, open_dialog_fn),           to: Driver
   @doc false

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -373,34 +373,6 @@ defmodule Wallaby.Phantom.Driver do
   end
 
   @doc """
-  Accept all JavaScript dialogs
-  """
-  def accept_dialogs(session) do
-    script = """
-    var page = this;
-    page.onAlert = function(msg) {}
-    page.onConfirm = function(msg) { return true; }
-    page.onPrompt = function(msg, defaultVal) { return defaultVal; }
-    return "ok";
-    """
-    {:ok, "ok"} = execute_phantom_script(session, script)
-  end
-
-  @doc """
-  Dismiss all JavaScript dialogs
-  """
-  def dismiss_dialogs(session) do
-    script = """
-    var page = this;
-    page.onAlert = function(msg) {}
-    page.onConfirm = function(msg) { return false; }
-    page.onPrompt = function(msg, defaultVal) { return null; }
-    return "ok";
-    """
-    {:ok, "ok"} = execute_phantom_script(session, script)
-  end
-
-  @doc """
   Accept one alert triggered within `fun` and return the alert message.
   """
   def accept_alert(%Session{} = session, fun) do

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -63,6 +63,11 @@ defmodule Wallaby.Query.ErrorMessage do
     The #{method} '#{selector}' is not a valid query.
     """
   end
+  def message(_, :unexpected_alert) do
+    """
+    There was an unexpected alert.
+    """
+  end
 
   def help(elements) do
     """


### PR DESCRIPTION
This PR does a few things. I would have normally broken this up but I wanted to get all of our chrome issues sorted at one time and I just got carried away. Here's the highlights:

* Fixes an issue with taking screenshots on chrome. Chrome doesn't support screenshots based on elements so we need to always screenshot using the session.
* Captured a specific chromedriver error for invalid selectors
* Fixes the dialog support for chrome. I'll discuss this in more detail below.
* Enable all of the tests for chrome.

In order to support dialogs and alerts in chrome I made the decision to remove `accept_dialogs` and `dismiss dialogs`. These were useful functions in phantom because phantom has no good way of managing dialog boxes. With chrome and selenium these functions are less useful since we don't have the limitations of phantomjs. I also felt that having these functions were simply less useful then simply being explicit by using `accept_prompt`, `accept_alert`, and the others. Thinking through it I felt like it would be good to remove a bit of the maintenance burden by deleting those functions.

I know its a lot of stuff but let me know what you think.