### PR TITLE
Include HTTPoison errors in Wallaby error message when request fails.

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -28,24 +28,30 @@ defmodule Wallaby.HTTPClient do
     make_request(method, url, Poison.encode!(params))
   end
 
-  defp make_request(method, url, body, retry_count \\ 0)
-  defp make_request(_, _, _, 5), do: raise "Wallaby had an internal issue with HTTPoison"
-  defp make_request(method, url, body, retry_count) do
+  defp make_request(method, url, body, retry_count \\ 0, retry_reasons \\ [])
+  defp make_request(_, _, _, 5, retry_reasons) do
+    ["Wallaby had an internal issue with HTTPoison:" | retry_reasons]
+    |> Enum.uniq()
+    |> Enum.join("\n")
+    |> raise
+  end
+  defp make_request(method, url, body, retry_count, retry_reasons) do
     method
     |> HTTPoison.request(url, body, headers(), request_opts())
     |> handle_response
     |> case do
-         {:error, :httpoison} ->
-           make_request(method, url, body, retry_count + 1)
-         result ->
-           result
+      {:error, :httpoison, error} ->
+        make_request(method, url, body, retry_count + 1, [inspect(error) | retry_reasons])
+
+      result ->
+        result
     end
   end
 
   defp handle_response(resp) do
     case resp do
-      {:error, %HTTPoison.Error{}} ->
-        {:error, :httpoison}
+      {:error, %HTTPoison.Error{} = error} ->
+        {:error, :httpoison, error}
 
       {:ok, %HTTPoison.Response{status_code: 204}} ->
         {:ok, %{"value" => nil}}

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -28,7 +28,7 @@ defmodule Wallaby.HTTPClient do
     make_request(method, url, Poison.encode!(params))
   end
 
-  defp make_request(method, url, body, retry_count \\ 0, retry_reasons \\ [])
+  defp make_request(method, url, body), do: make_request(method, url, body, 0, [])
   defp make_request(_, _, _, 5, retry_reasons) do
     ["Wallaby had an internal issue with HTTPoison:" | retry_reasons]
     |> Enum.uniq()

--- a/test/wallaby/http_client_test.exs
+++ b/test/wallaby/http_client_test.exs
@@ -54,5 +54,16 @@ defmodule Wallaby.HTTPClientTest do
       assert {:error, :stale_reference} =
         Client.request(:post, bypass_url(bypass, "/my_url"))
     end
+
+    test "includes the original HTTPoison error when there is one", %{bypass: bypass} do
+      expected_message =
+        "Wallaby had an internal issue with HTTPoison:\n%HTTPoison.Error{id: nil, reason: :econnrefused}"
+
+      Bypass.down bypass
+
+      assert_raise RuntimeError, expected_message, fn ->
+        Client.request(:post, bypass_url(bypass, "/my_url"))
+      end
+    end
   end
 end


### PR DESCRIPTION
To make it a little easier to track down issues.