### PR TITLE
Query.value and Query.attribute now available

### DIFF
--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -132,6 +132,24 @@ defmodule Wallaby.Integration.QueryTest do
     assert element
   end
 
+  test "queries can find an element by only value", %{session: session} do
+    element =
+      session
+      |> Browser.visit("/forms.html")
+      |> Browser.find(Query.value("an-input-value"))
+
+    assert element
+  end
+
+  test "queries can find an element by its attribute and value pair", %{session: session} do
+    element =
+      session
+      |> Browser.visit("/page_1.html")
+      |> Browser.find(Query.attribute("an-attribute", "an-attribute-value"))
+
+    assert element
+  end
+
   test "all returns an empty list if nothing is found", %{session: session} do
     elements =
       session

--- a/integration_test/support/pages/forms.html
+++ b/integration_test/support/pages/forms.html
@@ -140,6 +140,9 @@
       <button>Duplicate Button</button>
       <button>Duplicate Button</button>
     </div>
+
+    <input type="text" name="an-input" value="an-input-value"/>
+
     <script>
       setTimeout(function() {
         document.querySelector('.js-hidden').style.display = 'block'

--- a/integration_test/support/pages/page_1.html
+++ b/integration_test/support/pages/page_1.html
@@ -62,5 +62,7 @@
       <span class="conflicting">Visible</span>
       <span class="conflicting" style="display: none;">Visible</span>
     </div>
+
+    <span an-attribute="an-attribute-value">Span text</span>
   </body>
 </html>

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -88,7 +88,9 @@ defmodule Wallaby.Query do
                 | :option
                 | :select
                 | :file_field
+  @type attribute_key_value_pair :: {String.t, String.t}
   @type selector :: String.t
+                  | :attribute_key_value_pair
   @type html_validation :: :bad_label
                          | :button_type
                          | nil
@@ -142,6 +144,24 @@ defmodule Wallaby.Query do
     %Query{
       method: :text,
       selector: selector,
+      conditions: build_conditions(opts)
+    }
+  end
+
+  @doc """
+  Checks if the provided value is contained anywhere.
+  """
+  def value(selector, opts \\ []) do
+    attribute("value", selector, opts)
+  end
+
+  @doc """
+  Checks if the provided attribute, value pair is contained anywhere.
+  """
+  def attribute(name, value, opts \\ []) do
+    %Query{
+      method: :attribute,
+      selector: {name, value},
       conditions: build_conditions(opts)
     }
   end
@@ -296,6 +316,7 @@ defmodule Wallaby.Query do
   def compile(%{method: :select, selector: selector}), do: {:xpath, XPath.select(selector)}
   def compile(%{method: :file_field, selector: selector}), do: {:xpath, XPath.file_field(selector)}
   def compile(%{method: :text, selector: selector}), do: {:xpath, XPath.text(selector)}
+  def compile(%{method: :attribute, selector: {name, value}}), do: {:xpath, XPath.attribute(name, value)}
 
   def visible?(%Query{conditions: conditions}) do
     Keyword.get(conditions, :visible)

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -78,8 +78,20 @@ defmodule Wallaby.Query.ErrorMessage do
 
   defp found_error_message(query) do
     """
-    #{expected_count(query)}, #{visibility(query)} #{method(query)} '#{query.selector}' but #{result_count(query.result)}, #{visibility(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
+    #{expected_count(query)}, #{visibility(query)} #{method(query)} #{selector(query)} but #{result_count(query.result)}, #{visibility(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
     """
+  end
+
+  @doc """
+  Extracts the selector from the query
+  """
+  @spec selector(Query.t) :: String.t
+
+  def selector(%Query{selector: {name, value}}) do
+    "'#{name}' with value '#{value}'"
+  end
+  def selector(%Query{selector: selector}) do
+    "'#{selector}'"
   end
 
   @doc """
@@ -126,6 +138,9 @@ defmodule Wallaby.Query.ErrorMessage do
 
   def method(:text, true), do: "elements with the text"
   def method(:text, false), do: "element with the text"
+
+  def method(:attribute, true), do: "elements with the attribute"
+  def method(:attribute, false), do: "element with the attribute"
 
   def short_method(:css, count) when count > 1,  do: "elements"
   def short_method(:css, count) when count == 0, do: "elements"

--- a/lib/wallaby/query/xpath.ex
+++ b/lib/wallaby/query/xpath.ex
@@ -77,4 +77,11 @@ defmodule Wallaby.Query.XPath do
   def text(selector) do
     ~s{.//*[contains(normalize-space(text()), '#{selector}')]}
   end
+
+  @doc """
+  Matches any element by its attribute name and value pair.
+  """
+  def attribute(name, value) do
+    ~s{.//*[./@#{name} = "#{value}"]}
+  end
 end

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -109,6 +109,26 @@ defmodule Wallaby.Query.ErrorMessageTest do
       Expected to find 2, visible elements with the text 'test' but 0, visible elements with the text were found.
       """
     end
+
+    test "with value queries" do
+      message =
+        Query.value("test")
+        |> ErrorMessage.message(:not_found)
+        |> format
+      assert message == format """
+      Expected to find 1, visible element with the attribute 'value' with value 'test' but 0, visible elements with the attribute were found.
+      """
+    end
+
+    test "with attribute key, value pair queries" do
+      message =
+        Query.attribute("an-attribute", "an-attribute-value")
+        |> ErrorMessage.message(:not_found)
+        |> format
+      assert message == format """
+      Expected to find 1, visible element with the attribute 'an-attribute' with value 'an-attribute-value' but 0, visible elements with the attribute were found.
+      """
+    end
   end
 
   describe "visibility/1" do


### PR DESCRIPTION
Hi @keathley,

This PR will add two new features for the `Query` module. Now we are able to lookup HTML elements by:

- the `value` attribute (e.g. `Query.value("a-value")`)
- and for each `attribute-name` and `attribute-value` pair (e.q. `Query.attribute("an-attribute", "a-value")`)

Let me know what do you think! :rocket: 