### PR TITLE
Looking to get the discussion started regarding XPath module refactoring

### DIFF
--- a/lib/wallaby/query/xpath.ex
+++ b/lib/wallaby/query/xpath.ex
@@ -2,6 +2,8 @@ defmodule Wallaby.Query.XPath do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Readability.MaxLineLength
 
+  import Wallaby.Query.XPath.Expression
+
   @type query :: String.t
   @type xpath :: String.t
   @type name  :: query
@@ -31,7 +33,7 @@ defmodule Wallaby.Query.XPath do
   Match any radio buttons
   """
   def radio_button(query) do
-    ~s{.//input[./@type = 'radio'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "radio"]}
+    ~s{.//input[./@type = 'radio'][((#{id_or_name(query)} or ./@placeholder = "#{query}") or ./@id = //#{label(query)}/@for)] | .//#{label(query)}//.//input[./@type = "radio"]}
   end
 
   @doc """
@@ -40,21 +42,21 @@ defmodule Wallaby.Query.XPath do
   `hidden`, or `file`.
   """
   def fillable_field(query) when is_binary(query) do
-    ~s{.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]}
+    ~s{.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][((#{id_or_name(query)} or ./@placeholder = "#{query}") or ./@id = //#{label(query)}/@for)] | .//#{label(query)}//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]}
   end
 
   @doc """
   Match any checkboxes
   """
   def checkbox(query) do
-    ~s{.//input[./@type = 'checkbox'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "checkbox"]}
+    ~s{.//input[./@type = 'checkbox'][((#{id_or_name(query)} or ./@placeholder = "#{query}") or ./@id = //#{label(query)}/@for)] | .//#{label(query)}//.//input[./@type = "checkbox"]}
   end
 
   @doc """
   Match any `select` by name, id, or label.
   """
   def select(query) do
-    ~s{.//select[(((./@id = "#{query}" or ./@name = "#{query}")) or ./@name = //label[contains(normalize-space(string(.)), "#{query}")]/@for or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//select}
+    ~s{.//select[(#{id_or_name(query)} or ./@name = //#{label(query)}/@for or ./@id = //#{label(query)}/@for)] | .//#{label(query)}//.//select}
   end
 
   @doc """
@@ -68,7 +70,7 @@ defmodule Wallaby.Query.XPath do
   Matches any file field by name, id, or label
   """
   def file_field(query) do
-    ~s{.//input[./@type = 'file'][(((./@id = "#{query}" or ./@name = "#{query}")) or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = 'file']}
+    ~s{.//input[./@type = 'file'][(#{id_or_name(query)} or ./@id = //#{label(query)}/@for)] | .//#{label(query)}//.//input[./@type = 'file']}
   end
 
   @doc """

--- a/lib/wallaby/query/xpath/expression.ex
+++ b/lib/wallaby/query/xpath/expression.ex
@@ -1,0 +1,17 @@
+defmodule Wallaby.Query.XPath.Expression do
+  @moduledoc false
+
+  @doc """
+  label which next contains a string
+  """
+  def label(query) do
+    ~s{label[contains(normalize-space(string(.)), "#{query}")]}
+  end
+
+  @doc """
+  id or name attributes match string
+  """
+  def id_or_name(query) do
+    ~s{(./@id = "#{query}" or ./@name = "#{query}")}
+  end
+end


### PR DESCRIPTION
I'm not sure if this is the right direction but I'm looking for your feedback.  I feel like we could build up a module with more expressions that can be composed together for building the xpath expressions which are appropriate for each form control.  

Also, I've noticed some quirkiness around how each expression works for the different types of form controls, after some consideration and experimentation these seem intentional but makes it difficult to extract larger expressions to be useful across the board, I'm wondering if you have ideas here.