### PR TITLE
Return error message for obscure responses. Addresses #383 and #280

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -69,7 +69,9 @@ defmodule Wallaby.HTTPClient do
   defp check_status(response) do
     case Map.get(response, "status") do
       @status_obscured ->
-        {:error, :obscured}
+        message = get_in(response, ["value", "message"])
+
+        {:error, message}
       _  ->
         {:ok, response}
     end

--- a/test/wallaby/http_client_test.exs
+++ b/test/wallaby/http_client_test.exs
@@ -55,6 +55,23 @@ defmodule Wallaby.HTTPClientTest do
         Client.request(:post, bypass_url(bypass, "/my_url"))
     end
 
+    test "with an obscure status code", %{bypass: bypass} do
+      expected_message = "message from an obsure error"
+
+      Bypass.expect bypass, fn conn ->
+        send_resp(conn, 200, ~s<{
+          "sessionId": "abc123",
+          "status": 13,
+          "value": {
+            "message": "#{expected_message}"
+          }
+        }>)
+      end
+
+      assert {:error, ^expected_message} =
+        Client.request(:post, bypass_url(bypass, "/my_url"))
+    end
+
     test "includes the original HTTPoison error when there is one", %{bypass: bypass} do
       expected_message =
         "Wallaby had an internal issue with HTTPoison:\n%HTTPoison.Error{id: nil, reason: :econnrefused}"

--- a/test/wallaby/phantom/server/server_state_test.exs
+++ b/test/wallaby/phantom/server/server_state_test.exs
@@ -57,7 +57,7 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
     test "with no phantom_args" do
       state = build_server_state(
         phantom_path: "phantomjs",
-        port_number: 8000,
+        port_number: 8000
       )
 
       assert %ExternalCommand{


### PR DESCRIPTION
This will still throw the `MatchError`, but will carry the corresponding error message to the user instead of only `:obscure`.

Partially addresses #383 and #280.