### PR TITLE
silence quoted keyword warning from recent elixir versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Wallaby.Mixfile do
      aliases: ["test.all": ["test", "test.drivers"],
                "test.drivers": &test_drivers/1],
      preferred_cli_env: [
-       "coveralls": :test,
+       coveralls: :test,
        "coveralls.detail": :test,
        "coveralls.post": :test,
        "coveralls.html": :test,


### PR DESCRIPTION
A minor update to silence the compiler warning `found quoted keyword "coveralls" but the quotes are not required.` coming from a recent version of elixir