### PR TITLE
Upgrade Selenium Server and GeckoDriver for CI

### DIFF
--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -7,6 +7,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @type http_method :: :post | :get | :delete
   @type url :: String.t
 
+  @web_element_identifier "element-6066-11e4-a52e-4f735466cecf"
+
   @doc """
   Create a session with the base url.
   """
@@ -359,6 +361,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
 
   @spec cast_as_element(Session.t | Element.t, map) :: Element.t
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
+    cast_as_element(parent, %{@web_element_identifier => id})
+  end
+  defp cast_as_element(parent, %{@web_element_identifier => id}) do
     %Wallaby.Element{
       id: id,
       session_url: parent.session_url,

--- a/test/tools/start_webdriver.sh
+++ b/test/tools/start_webdriver.sh
@@ -12,7 +12,7 @@ if [ "$WALLABY_DRIVER" = "selenium" ]; then
 
   if [ "$WALLABY_SELENIUM_VERSION" = "3" ]; then
 
-    curl https://selenium-release.storage.googleapis.com/3.4/selenium-server-standalone-3.4.0.jar -o $HOME/selenium.jar
+    curl https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar -o $HOME/selenium.jar
     # Geckodriver requires java 8.
     sudo add-apt-repository -y ppa:openjdk-r/ppa
     sudo apt-get update && sudo apt-get install -y openjdk-8-jdk
@@ -23,7 +23,7 @@ if [ "$WALLABY_DRIVER" = "selenium" ]; then
     jdk_switcher use openjdk8
 
     # Download geckodriver
-    curl -L https://github.com/mozilla/geckodriver/releases/download/v0.16.0/geckodriver-v0.16.0-linux64.tar.gz -o $HOME/geckodriver.tar.gz
+    curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -o $HOME/geckodriver.tar.gz
     tar xfz $HOME/geckodriver.tar.gz -C $HOME/bin
 
     # Download latest firefox

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -111,6 +111,33 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         driver: Wallaby.Experimental.Selenium,
       }
     end
+
+    test "with newer web element identifier", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element_id = ":wdc:1491326583887"
+      query = ".blue" |> Query.css |> Query.compile
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/elements"
+        assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": [{"element-6066-11e4-a52e-4f735466cecf": "#{element_id}"}]
+        }>)
+      end
+
+      assert {:ok, [element]} = Client.find_elements(session, query)
+      assert element == %Element{
+        id: element_id,
+        parent: session,
+        session_url: session.url,
+        url: "#{session.url}/element/#{element_id}",
+        driver: Wallaby.Experimental.Selenium,
+      }
+    end
   end
 
   describe "set_value/2" do


### PR DESCRIPTION
We are seeing some failures on CI for `$WALLABY_SELENIUM_VERSION=3` and noticed that the Selenium and GeckoDriver versions were well behind, but Firefox was always set to latest. Hopefully updating them will allow them to cooperate with Firefox.