### PR TITLE
Use new web element identifier when pattern matching on element

### DIFF
--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -7,6 +7,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @type http_method :: :post | :get | :delete
   @type url :: String.t
 
+  @web_element_identifier "element-6066-11e4-a52e-4f735466cecf"
+
   @doc """
   Create a session with the base url.
   """
@@ -359,6 +361,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
 
   @spec cast_as_element(Session.t | Element.t, map) :: Element.t
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
+    cast_as_element(parent, %{@web_element_identifier => id})
+  end
+  defp cast_as_element(parent, %{@web_element_identifier => id}) do
     %Wallaby.Element{
       id: id,
       session_url: parent.session_url,

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -111,6 +111,33 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         driver: Wallaby.Experimental.Selenium,
       }
     end
+
+    test "with newer web element identifier", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element_id = ":wdc:1491326583887"
+      query = ".blue" |> Query.css |> Query.compile
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/elements"
+        assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": [{"element-6066-11e4-a52e-4f735466cecf": "#{element_id}"}]
+        }>)
+      end
+
+      assert {:ok, [element]} = Client.find_elements(session, query)
+      assert element == %Element{
+        id: element_id,
+        parent: session,
+        session_url: session.url,
+        url: "#{session.url}/element/#{element_id}",
+        driver: Wallaby.Experimental.Selenium,
+      }
+    end
   end
 
   describe "set_value/2" do


### PR DESCRIPTION
According to the [WebDriver specification](https://www.w3.org/TR/webdriver/#elements), elements will be returned with the web element identifier as a property on the response object. This is a constant of `element-6066-11e4-a52e-4f735466cecf`. I am not sure of the significance of this constant, however.