### PR TITLE
Don't fail the build on Coveralls timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - bash $TRAVIS_BUILD_DIR/test/tools/start_webdriver.sh
 
 script:
-  - mix coveralls.travis
+  - mix coveralls.safe_travis
   - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
   - mix credo --strict
 

--- a/dialyzer.ignore_warnings
+++ b/dialyzer.ignore_warnings
@@ -1,0 +1,3 @@
+:0: Unknown function 'Elixir.Mix':shell/0
+:0: Unknown function 'Elixir.Mix.Tasks.Coveralls':do_run/2
+lib/mix/tasks/safe_travis.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available

--- a/lib/mix/tasks/safe_travis.ex
+++ b/lib/mix/tasks/safe_travis.ex
@@ -1,15 +1,16 @@
 defmodule Mix.Tasks.Coveralls.SafeTravis do
-   @moduledoc false
+  @moduledoc false
+  alias Mix.Tasks.Coveralls
 
-   use Mix.Task
+  use Mix.Task
 
-   @preferred_cli_env :test
-   @shortdoc "A safe `coveralls.travis` variant that doesn't crash on failed upload."
+  @preferred_cli_env :test
+  @shortdoc "A safe `coveralls.travis` variant that doesn't crash on failed upload."
 
-   def run(args) do
-     Mix.Tasks.Coveralls.do_run(args, type: "travis")
-   rescue
-     e in ExCoveralls.ReportUploadError ->
-       Mix.shell().error("Failed coveralls upload: #{Exception.message(e)}")
-   end
- end
+  def run(args) do
+    Coveralls.do_run(args, type: "travis")
+  rescue
+    e in ExCoveralls.ReportUploadError ->
+      Mix.shell().error("Failed coveralls upload: #{Exception.message(e)}")
+  end
+end

--- a/lib/mix/tasks/safe_travis.ex
+++ b/lib/mix/tasks/safe_travis.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.Coveralls.SafeTravis do
+   @moduledoc false
+
+   use Mix.Task
+
+   @preferred_cli_env :test
+   @shortdoc "A safe `coveralls.travis` variant that doesn't crash on failed upload."
+
+   def run(args) do
+     Mix.Tasks.Coveralls.do_run(args, type: "travis")
+   rescue
+     e in ExCoveralls.ReportUploadError ->
+       Mix.shell().error("Failed coveralls upload: #{Exception.message(e)}")
+   end
+ end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Wallaby.Mixfile do
        "test.drivers": :test],
      test_coverage: [tool: ExCoveralls],
      test_paths: test_paths(@selected_driver),
-     dialyzer: [plt_add_apps: [:inets]]]
+     dialyzer: [plt_add_apps: [:inets], ignore_warnings: "dialyzer.ignore_warnings"]]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Wallaby.Mixfile do
        "coveralls.post": :test,
        "coveralls.html": :test,
        "coveralls.travis": :test,
+       "coveralls.safe_travis": :test,
        "test.all": :test,
        "test.drivers": :test],
      test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
Coveralls timing out is causing a lot of false positives on CI. This should recover from excoveralls failures.

Shamelessly ripped from [pinterest/elixir-thrift](https://github.com/pinterest/elixir-thrift/pull/389/files)