### PR TITLE
Print outerHTML when passing an Element to IO.inspect/2

### DIFF
--- a/integration_test/cases/inspect_test.exs
+++ b/integration_test/cases/inspect_test.exs
@@ -1,0 +1,39 @@
+defmodule Wallaby.Integration.InspectTest do
+  use Wallaby.Integration.SessionCase, async: true
+  import ExUnit.CaptureIO
+
+  describe "inspect/2" do
+    test "prints the outerHTML of the element", %{session: session} do
+      expected = """
+      #{IO.ANSI.cyan}outerHTML:
+
+      #{IO.ANSI.reset}#{IO.ANSI.yellow}<body class="bootstrap index-page">
+        <h1 id="header">Test Index</h1>
+        <ul>
+          <li><a href="page_1.html">Page 1</a></li>
+          <li><a href="page_2.html">Page 2</a></li>
+          <li><a href="page_3.html">Page 3</a></li>
+        </ul>
+
+        <div id="parent">
+          The Parent
+          <div id="child">
+            The Child
+          </div>
+        </div>
+      </body>#{IO.ANSI.reset}
+      """
+      |> String.replace(~r/\s/, "")
+
+      actual = capture_io(fn ->
+        session
+        |> visit("/index.html")
+        |> find(Query.css("body"))
+        |> IO.inspect
+      end)
+      |> String.replace(~r/\s/, "")
+
+      assert actual =~ expected
+    end
+  end
+end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -199,3 +199,18 @@ defmodule Wallaby.Element do
     attr(element, "value")
   end
 end
+
+defimpl Inspect, for: Wallaby.Element  do
+  import Inspect.Algebra
+
+  def inspect(element, opts) do
+    outer_html = Wallaby.Element.attr(element, "outerHTML")
+
+    concat([
+      Inspect.Any.inspect(element, opts),
+      "\n\n",
+      IO.ANSI.cyan <> "outerHTML:\n\n" <> IO.ANSI.reset,
+      IO.ANSI.yellow <> outer_html <> IO.ANSI.reset
+    ])
+  end
+end


### PR DESCRIPTION
Addresses #266 

When passing a `Wallaby.Element` to `IO.inspect/2`, the elements outerHTML will be printed along with the normal representation of a struct, like so:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/5523984/48318606-3f6f8980-e5d1-11e8-8359-eeb3db0bbdd3.png">

I would like some feedback on a few things:

- Where is the best place to define the `Inspect` implementation?
- Keep/change/throw out the coloring?
- Is the format alright?
- Should we request the `outerHTML` data when running inspect, or should the outerHTML be added to the `Wallaby.Element` struct itself?

Thanks!

cc/ @keathley @knewter @nathanl 