### PR TITLE
Find elements by text that contain single quotes

### DIFF
--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -132,6 +132,15 @@ defmodule Wallaby.Integration.QueryTest do
     assert element
   end
 
+  test "queries can find an element by that has single quotes in it", %{session: session} do
+    element =
+      session
+      |> Browser.visit("/page_1.html")
+      |> Browser.find(Query.text("aren't"))
+
+    assert element
+  end
+
   test "queries can find an element by only value", %{session: session} do
     element =
       session

--- a/integration_test/support/pages/page_1.html
+++ b/integration_test/support/pages/page_1.html
@@ -54,6 +54,8 @@
       Text
       Text 2
     </div>
+    
+    <span>Single quotes aren't hard</span>
 
     <p class="plus-one">+ 1</p>
 

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -63,7 +63,7 @@ defmodule Wallaby.Query do
   query that will be sent to the driver:
 
       iex> Wallaby.Query.compile Wallaby.Query.text("my text")
-      {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
+      {:xpath, ".//*[contains(normalize-space(text()), \"my text\")]"}
 
   So, whenever you're not sure whatever a specific query will do just compile
   it to get all the details!
@@ -299,8 +299,8 @@ defmodule Wallaby.Query do
   @doc """
   Compiles a query into css or xpath so its ready to be sent to the driver
 
-      iex> Wallaby.Query.compile Wallaby.Query.text("my text")
-      {:xpath, ".//*[contains(normalize-space(text()), 'my text')]"}
+      iex> Wallaby.Query.compile Wallaby.Query.text("my text") 
+      {:xpath, ".//*[contains(normalize-space(text()), \\"my text\\")]"}
       iex> Wallaby.Query.compile Wallaby.Query.css("#some-id")
       {:css, "#some-id"}
   """

--- a/lib/wallaby/query/xpath.ex
+++ b/lib/wallaby/query/xpath.ex
@@ -75,7 +75,7 @@ defmodule Wallaby.Query.XPath do
   Matches any element by its inner text.
   """
   def text(selector) do
-    ~s{.//*[contains(normalize-space(text()), '#{selector}')]}
+    ~s{.//*[contains(normalize-space(text()), "#{selector}")]}
   end
 
   @doc """


### PR DESCRIPTION
Addresses #344.

I wasn't able to find a way to escape the single quotes in the xpath expression, so I resorted to switching to double quotes as the delimiters.

Some places I found people saying you could escape them by doubling them, but that didn't seem to work.

Let me know what you think.

cc/ @keathley @mcasper