### PR TITLE
Allow newlines in chrome log messages

### DIFF
--- a/lib/wallaby/experimental/chrome/logger.ex
+++ b/lib/wallaby/experimental/chrome/logger.ex
@@ -1,6 +1,6 @@
 defmodule Wallaby.Experimental.Chrome.Logger do
   @moduledoc false
-  @log_regex ~r/^(?<url>\S+) (?<line>\d+):(?<column>\d+) (?<message>.*)$/
+  @log_regex ~r/^(?<url>\S+) (?<line>\d+):(?<column>\d+) (?<message>.*)$/s
   @string_regex ~r/^"(?<string>.+)"$/
 
   def parse_log(%{"level" => "SEVERE", "source" => "javascript", "message" => msg}) do

--- a/test/wallaby/experimental/chrome/logger_test.exs
+++ b/test/wallaby/experimental/chrome/logger_test.exs
@@ -31,6 +31,15 @@ defmodule Wallaby.Experimental.Chrome.LoggerTest do
       assert capture_io(fun) == "Array(2)\n"
     end
 
+    test "prints messages with embedded newlines" do
+      fun = fn ->
+        build_log(~s[http://localhost:52615/logs.html 13:14 "test\nlog"])
+        |> Logger.parse_log
+      end
+
+      assert capture_io(fun) == "\"test\nlog\"\n"
+    end
+
     test "pretty prints json" do
       message = ~s(http://localhost:54579/logs.html 13:14 "{\"href\":\"http://localhost:54579/logs.html\",\"ancestorOrigins\":{}}")
 


### PR DESCRIPTION
I ran into this issue today where some of the logs returned by chromedriver for one of my tests had embedded newlines which caused the logger Regex to fail (return nil) which led to throwing a `CaseClauseError` here:  https://github.com/keathley/wallaby/blob/bfddea8a7806e6a8787741577ea4054aab846a9c/lib/wallaby/experimental/chrome/logger.ex#L14-L16

This PR adds the `s` Regex modifier allowing newlines to be matched by the dot (.)
