### PR TITLE
Make phantom start timeout configurable

### DIFF
--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -95,8 +95,8 @@ defmodule Wallaby.Phantom.Server do
 
   @spec start_phantom(ServerState.t) ::
     {:ok, ServerState.t} | {:error, StartTask.error_reason}
-  defp start_phantom(%ServerState{} = state) do
-    state |> StartTask.async() |> Task.await()
+  defp start_phantom(%ServerState{phantom_start_timeout: timeout} = state) do
+    state |> StartTask.async() |> Task.await(timeout)
   end
 
   @spec wait_for_stop(os_pid) :: nil

--- a/lib/wallaby/phantom/server/server_state.ex
+++ b/lib/wallaby/phantom/server/server_state.ex
@@ -16,6 +16,7 @@ defmodule Wallaby.Phantom.Server.ServerState do
     wrapper_script_port: port | nil,
     wrapper_script_os_pid: os_pid | nil,
     phantom_os_pid: os_pid | nil,
+    phantom_start_timeout: integer
   }
 
   defstruct [
@@ -25,14 +26,16 @@ defmodule Wallaby.Phantom.Server.ServerState do
     :phantom_args,
     :wrapper_script_port,
     :wrapper_script_os_pid,
-    :phantom_os_pid]
+    :phantom_os_pid,
+    :phantom_start_timeout]
 
   @type workspace_path :: String.t
 
   @type new_opt ::
     {:port_number, port_number} |
     {:phantom_path, String.t} |
-    {:phantom_args, [String.t] | String.t}
+    {:phantom_args, [String.t] | String.t} |
+    {:phantom_start_timeout, integer}
 
   @spec new(workspace_path, [new_opt]) :: t
   def new(workspace_path, params \\ []) do
@@ -45,6 +48,8 @@ defmodule Wallaby.Phantom.Server.ServerState do
       phantom_args: params
                     |> Keyword.get_lazy(:phantom_args, &phantom_args_from_env/0)
                     |> normalize_phantomjs_args,
+      phantom_start_timeout: Keyword.get_lazy(params, :phantom_start_timeout,
+                                              &phantom_start_timeout_from_env/0)
     }
   end
 
@@ -77,6 +82,11 @@ defmodule Wallaby.Phantom.Server.ServerState do
   @spec phantom_args_from_env :: [String.t] | String.t
   defp phantom_args_from_env do
     Application.get_env(:wallaby, :phantomjs_args, "")
+  end
+
+  @spec phantom_start_timeout_from_env :: integer
+  defp phantom_start_timeout_from_env do
+    Application.get_env(:wallaby, :phantomjs_start_timeout, 5_000)
   end
 
   @spec normalize_phantomjs_args(String.t | [String.t]) :: [String.t]


### PR DESCRIPTION
This PR is to start the discussion on a possible way of solving the following issue:

On my and my colleague's Mac, `wallaby` regularly (1 in 10 times, especially when Mac is doing something else) fails to start, because `phantomjs` start times out after 5 seconds.
Increasing this value resolves this.

Is there a specific reason why the `phantomjs` start happens in an asynchronous task?
Is it possible that this process hangs forever and thus the timeout needs to be controlled with `Task.await`?
