### PR TITLE
Add selected condition to query

### DIFF
--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -19,6 +19,46 @@ defmodule Wallaby.Integration.QueryTest do
     assert Enum.count(elements) == 2
   end
 
+  describe "filtering queries by selected status" do
+    test "raises QueryError if too many elements are specified", %{session: session} do
+      assert_raise Wallaby.QueryError, fn ->
+        session
+        |> Browser.visit("/forms.html")
+        |> Browser.find(Query.css(".select-options", count: 3, selected: false))
+      end
+    end
+
+    test "finds elements that are not selected", %{session: session} do
+      elements =
+        session
+        |> Browser.visit("/forms.html")
+        |> Browser.click(Query.option("Select Option 2"))
+        |> Browser.find(Query.css(".select-options", count: 2, selected: false))
+
+      assert Enum.count(elements) == 2
+    end
+
+    test "finds elements that are selected", %{session: session} do
+      element =
+        session
+        |> Browser.visit("/forms.html")
+        |> Browser.click(Query.option("Select Option 2"))
+        |> Browser.find(Query.css(".select-options", count: 1, selected: true))
+
+      assert Element.text(element) == "Select Option 2"
+    end
+
+    test "finds all elements (whether selected or not) by default", %{session: session} do
+      elements =
+        session
+        |> Browser.visit("/forms.html")
+        |> Browser.click(Query.option("Select Option 2"))
+        |> Browser.find(Query.css(".select-options", count: 3))
+
+      assert Enum.count(elements) == 3
+    end
+  end
+
   describe "filtering queries by visibility" do
     test "finds elements that are invisible", %{session: session} do
       assert_raise Wallaby.QueryError, fn ->

--- a/integration_test/support/pages/forms.html
+++ b/integration_test/support/pages/forms.html
@@ -34,9 +34,9 @@
 
       <label for='my-select'>My Select</label>
       <select name='my-select'>
-        <option id='select-option-1'>Select Option 1</option>
-        <option id='select-option-2'>Select Option 2</option>
-        <option id='select-option-3'>Select Option 3</option>
+        <option id='select-option-1' class="select-options">Select Option 1</option>
+        <option id='select-option-2' class="select-options">Select Option 2</option>
+        <option id='select-option-3' class="select-options">Select Option 3</option>
       </select>
 
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -862,6 +862,17 @@ defmodule Wallaby.Browser do
     {:ok, Enum.filter(elements, &(Element.visible?(&1) == visible))}
   end
 
+  defp validate_selected(query, elements) do
+    case Query.selected?(query) do
+      :any ->
+        {:ok, elements}
+      true ->
+        {:ok, Enum.filter(elements, &(Element.selected?(&1)))}
+      false ->
+        {:ok, Enum.reject(elements, &(Element.selected?(&1)))}
+    end
+  end
+
   defp validate_count(query, elements) do
     if Query.matches_count?(query, Enum.count(elements)) do
       {:ok, elements}
@@ -908,6 +919,7 @@ defmodule Wallaby.Browser do
              {:ok, elements} <- driver.find_elements(parent, compiled_query),
              {:ok, elements} <- validate_visibility(query, elements),
              {:ok, elements} <- validate_text(query, elements),
+             {:ok, elements} <- validate_selected(query, elements),
              {:ok, elements} <- validate_count(query, elements),
              {:ok, elements} <- do_at(query, elements)
          do

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -28,6 +28,7 @@ defmodule Wallaby.Query do
 
     * `:count` - The number of elements that should be found (default: 1).
     * `:visible` - Determines if the query should return only visible elements (default: true).
+    * `:selected` - Determines if the query should return only selected elements (default: :any for selected and unselected).
     * `:text` - Text that should be found inside the element (default: nil).
     * `:at` - The position number of the element to select if multiple elements satisfy the selection criteria. (:all for all elements)
 
@@ -98,6 +99,7 @@ defmodule Wallaby.Query do
     count: non_neg_integer,
     text: String.t,
     visible: boolean(),
+    selected: boolean() | :any,
     minimum: non_neg_integer,
     at: pos_integer
   ]
@@ -306,7 +308,7 @@ defmodule Wallaby.Query do
   @doc """
   Compiles a query into css or xpath so its ready to be sent to the driver
 
-      iex> Wallaby.Query.compile Wallaby.Query.text("my text") 
+      iex> Wallaby.Query.compile Wallaby.Query.text("my text")
       {:xpath, ".//*[contains(normalize-space(text()), \\"my text\\")]"}
       iex> Wallaby.Query.compile Wallaby.Query.css("#some-id")
       {:css, "#some-id"}
@@ -327,6 +329,10 @@ defmodule Wallaby.Query do
 
   def visible?(%Query{conditions: conditions}) do
     Keyword.get(conditions, :visible)
+  end
+
+  def selected?(%Query{conditions: conditions}) do
+    Keyword.get(conditions, :selected)
   end
 
   def count(%Query{conditions: conditions}) do
@@ -373,11 +379,16 @@ defmodule Wallaby.Query do
     |> add_visibility
     |> add_text
     |> add_count
+    |> add_selected
     |> add_at
   end
 
   defp add_visibility(opts) do
     Keyword.put_new(opts, :visible, true)
+  end
+
+  defp add_selected(opts) do
+    Keyword.put_new(opts, :selected, :any)
   end
 
   defp add_text(opts) do

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -78,7 +78,7 @@ defmodule Wallaby.Query.ErrorMessage do
 
   defp found_error_message(query) do
     """
-    #{expected_count(query)}, #{visibility(query)} #{method(query)} #{selector(query)} but #{result_count(query.result)}, #{visibility(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
+    #{expected_count(query)}, #{visibility_and_selection(query)} #{method(query)} #{selector(query)} but #{result_count(query.result)}, #{visibility_and_selection(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
     """
   end
 
@@ -173,6 +173,15 @@ defmodule Wallaby.Query.ErrorMessage do
     "text: '#{text}'"
   end
   def condition(_), do: nil
+
+  @spec visibility_and_selection(Query.t) :: String.t
+  defp visibility_and_selection(query) do
+    case Query.selected?(query) do
+      true -> "#{visibility(query)}, selected"
+      false -> "#{visibility(query)}, unselected"
+      :any -> visibility(query)
+    end
+  end
 
   @doc """
   Converts the visibilty attribute into a human readable form.

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -92,6 +92,30 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message =~ ~r/query is invalid/
     end
 
+    test "when the result is supposed to be selected" do
+      message =
+        Query.css(".test", count: 1, selected: true)
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message == format """
+      Expected to find 1, visible, selected element that matched the css '.test' but 0,
+      visible, selected elements were found.
+      """
+    end
+
+    test "when the result is not supposed to be selected" do
+      message =
+        Query.css(".test", count: 1, selected: false)
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message == format """
+      Expected to find 1, visible, unselected element that matched the css '.test' but 0,
+      visible, unselected elements were found.
+      """
+    end
+
     test "with text queries" do
       message =
         Query.text("test")


### PR DESCRIPTION
This is an attempt to handle https://github.com/keathley/wallaby/issues/380

Description
===========

Adds a `selected` condition to queries. This should only work with options, radio buttons, and checkboxes (since it uses `Element.selected?/1` underneath).

The usage is similar to the `visible` option for a query function: e.g. `Query.css("selector", selected: true)`. The default case, when neither `selected: true` nor `selected: false` is passed sets the condition to `:any`. In this way, if neither `true` nor `false` are specified, the query will return both selected and unselected elements. Having `true`, `false` or `:any` feels a bit unclean to me since now we have a boolean or a random atom `:any`, but I couldn't think of a better way to handle that. I'm happy to change that if there are better options. 

I also updated the error message to include the notion of whether selected or unselected elements were being searched for -> `"... 1, visible, selected element, but ..."`. I wasn't sure if this was desired, so I'm happy to remove this if it doesn't make sense. 

Thanks so much for the time spent reviewing this, and let me know if you'd like any changes or if we should just close this altogether and try a different approach. 