### PR TITLE
Remove false comment about default hackney config

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,6 @@ sent along on every request. This can be controlled with the `:hackney_options`
 setting in `config.exs`.
 
 ```elixir
-# default values
 config :wallaby,
   hackney_options: [timeout: :infinity, recv_timeout: :infinity]
 


### PR DESCRIPTION
For the user of the library, there is no default hackney config:

```
iex(1)> Application.ensure_all_started(:wallaby)
{:ok,
 [:unicode_util_compat, :idna, :mimerl, :certifi, :ssl_verify_fun, :metrics,
  :hackney, :httpoison, :poolboy, :poison, :wallaby]}

iex(2)> Application.get_env(:wallaby, :hackney_options, [])
[]
```