### PR TITLE
When creating session, read sessionID from value object when it's present

### DIFF
--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -37,7 +37,7 @@ defmodule Wallaby.Experimental.Selenium do
     capabilities = Map.merge(default_capabilities(), capabilities)
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
-      id = response["sessionId"]
+      id = response["sessionId"] || get_in(response, ["value", "sessionId"])
 
       session = %Wallaby.Session{
         session_url: base_url <> "session/#{id}",


### PR DESCRIPTION
Newer platforms, like the web drivers for Safari 12.0 on macOS Mojave or Edge 18 on Windows 10, seem to respond with a different response format (tested on Browserstack Automate). It may be that this is aligned the new W3C WebDriver spec, but I haven't checked.

Related issue: #386 