### PR TITLE
Add functions for query options

### DIFF
--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -19,6 +19,24 @@ defmodule Wallaby.Integration.QueryTest do
     assert Enum.count(elements) == 2
   end
 
+  test "queries can be composed via functions", %{session: session} do
+    composed_query =
+      Query.css(".select-options")
+      |> Query.visible(true)
+      |> Query.selected(true)
+      |> Query.text("Select Option 2")
+      |> Query.count(1)
+      |> Query.at(0)
+
+    element =
+      session
+      |> Browser.visit("/forms.html")
+      |> Browser.click(Query.option("Select Option 2"))
+      |> Browser.find(composed_query)
+
+    assert Element.text(element) == "Select Option 2"
+  end
+
   describe "filtering queries by selected status" do
     test "raises QueryError if too many elements are specified", %{session: session} do
       assert_raise Wallaby.QueryError, fn ->

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -32,6 +32,14 @@ defmodule Wallaby.Query do
     * `:text` - Text that should be found inside the element (default: nil).
     * `:at` - The position number of the element to select if multiple elements satisfy the selection criteria. (:all for all elements)
 
+  Query options can also be set via functions by the same names:
+
+  ```
+  Query.css(".names")
+  |> Query.visible(true)
+  |> Query.count(3)
+  ```
+
   ## Re-using queries
 
   It is often convenient to re-use queries. The easiest way is to use module
@@ -140,9 +148,36 @@ defmodule Wallaby.Query do
   end
 
   @doc """
-  Checks if the provided text is contained anywhere.
+  This function can be used in one of two ways.
+
+  The first is by providing a selector and possible options. This generates a
+  query that checks if the provided text is contained anywhere.
+
+  ## Example
+
+    ```
+    Query.text("Submit", count: 1)
+    ```
+
+  The second is by providing an existing query and a value to set as the `text`
+  option.
+
+  ## Example
+
+    ```
+    submit_button = Query.css("#submit-button")
+
+    update_button = submit_button |> Query.text("Update")
+    create_button = submit_button |> Query.text("Create")
+    ```
   """
-  def text(selector, opts \\ []) do
+  def text(query_or_selector, value_or_opts \\ [])
+
+  def text(%Query{} = query, value) do
+    update_condition(query, :text, value)
+  end
+
+  def text(selector, opts) do
     %Query{
       method: :text,
       selector: selector,
@@ -294,6 +329,68 @@ defmodule Wallaby.Query do
     }
   end
 
+  @doc """
+  Updates a query's visibility (visible if `true`, hidden if `false`).
+
+  ## Examples
+
+    ```
+    Query.css("#modal")
+    |> Query.visible(true)
+
+    Query.css("#modal")
+    |> Query.visible(false)
+    ```
+  """
+  def visible(query, value) do
+    update_condition(query, :visible, value)
+  end
+
+  @doc """
+  Updates a query's `selected` option.
+
+  ## Examples
+
+    ```
+    Query.css("#select-dropdown")
+    |> Query.selected(true)
+
+    Query.css("#select-dropdown")
+    |> Query.selected(false)
+    ```
+  """
+  def selected(query, value) do
+    update_condition(query, :selected, value)
+  end
+
+  @doc """
+  Updates a query's `count` option.
+
+  ## Example
+
+    ```
+    Query.css(".names > li")
+    |> Query.count(2)
+    ```
+  """
+  def count(query, value) do
+    update_condition(query, :count, value)
+  end
+
+  @doc """
+  Updates a query's `at` option.
+
+  ## Example
+
+    ```
+    Query.css(".names")
+    |> Query.at(3)
+    ```
+  """
+  def at(query, value) do
+    update_condition(query, :at, value)
+  end
+
   def validate(query) do
     cond do
       query.conditions[:minimum] > query.conditions[:maximum] ->
@@ -408,5 +505,10 @@ defmodule Wallaby.Query do
 
   defp add_at(opts) do
     Keyword.put_new(opts, :at, :all)
+  end
+
+  defp update_condition(%Query{conditions: conditions} = query, key, value) do
+    updated_conditions = Keyword.put(conditions, key, value)
+    %Query{query | conditions: updated_conditions}
   end
 end

--- a/test/wallaby/query_test.exs
+++ b/test/wallaby/query_test.exs
@@ -95,4 +95,85 @@ defmodule Wallaby.QueryTest do
       assert Query.validate(query) == {:error, :min_max}
     end
   end
+
+  describe "visible/2" do
+    test "marks query as visible when true is passed" do
+      query =
+        Query.css("#test", visible: false)
+        |> Query.visible(true)
+
+      assert Query.visible?(query)
+    end
+
+    test "marks query as hidden when false is passed" do
+      query =
+        Query.css("#test", visible: true)
+        |> Query.visible(false)
+
+      refute Query.visible?(query)
+    end
+  end
+
+  describe "selected/2" do
+    test "marks query as selected when true is passed" do
+      query =
+        Query.css("#test", selected: false)
+        |> Query.selected(true)
+
+      assert Query.selected?(query)
+    end
+
+    test "marks query as unselected when false is passed" do
+      query =
+        Query.css("#test", selected: true)
+        |> Query.selected(false)
+
+      refute Query.selected?(query)
+    end
+  end
+
+  describe "text/2 when a query is passed" do
+    test "sets the text option of the query" do
+      query =
+        Query.css("#test")
+        |> Query.text("Submit")
+
+      assert Query.inner_text(query) == "Submit"
+    end
+  end
+
+  describe "text/2 when a selector is passed" do
+    test "creates a text query" do
+      query = Query.text("Submit")
+
+      assert query.method == :text
+    end
+
+    test "accepts options" do
+      query = Query.text("Submit", count: 1)
+
+      assert query.method == :text
+      assert Query.count(query) == 1
+    end
+  end
+
+  describe "count/2" do
+    test "sets the count in a query" do
+      query =
+        Query.css(".test")
+        |> Query.count(9)
+
+      assert Query.count(query) == 9
+    end
+  end
+
+  describe "at/2" do
+    test "sets at option in a query" do
+      query =
+        Query.css(".test")
+        |> Query.at(3)
+
+      assert Query.at_number(query) == 3
+    end
+  end
 end


### PR DESCRIPTION
Attempt to address #404 

Description
============

Adds functions `visible/2`, `selected/2`, `text/2`, `count/2`, and `at/2` for query options to compose queries.

```elixir
# Previously
query =
  Query.css(
    ".select-options",
    visible: true,
    selected: true,
    text: "Select Option 2",
    count: 1,
    at: 0
  )

# Now we can also do the following
query =
  Query.css(".select-options")
  |> Query.visible(true)
  |> Query.selected(true)
  |> Query.text("Select Option 2")
  |> Query.count(1)
  |> Query.at(0)
```

Note on `Query.text/2`
---------------------

We decided to go ahead an leave the two versions of `Query.text/2` for now, even though they perform different actions. One version creates a query of `method: :text` and the other adds the `text` condition to an existing query (see https://github.com/keathley/wallaby/issues/404#issuecomment-459343916 for more on that).

Note on docs
------------

I decided _not_ to use doc tests for the examples introduced. I decided against doc tests because the important aspect of the examples were getting lost amongst so much data returned. 

For example, when trying to write a doc test for `text/2`, I was trying to show that a `Query.text("Submit", count: 1)` would create a query struct with `method: :text`, `selector: "Submit`, and `count: 1`. But it felt like the important information got lost when displayed like this,

```elixir
iex> Wallaby.Query.text("Submit", count: 1)
%Wallaby.Query{method: :text, selector: "Submit", html_validation: nil, conditions: [text: nil, visible: true, selected: :any, minimum: nil, at: 0, count: 1], result: nil}
```

That being said, I would be happy to change all the examples introduced into doc tests if that is preferred. 