### PR TITLE
Add visible: :any option to Query

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -857,9 +857,14 @@ defmodule Wallaby.Browser do
   end
 
   defp validate_visibility(query, elements) do
-    visible = Query.visible?(query)
-
-    {:ok, Enum.filter(elements, &(Element.visible?(&1) == visible))}
+    case Query.visible?(query) do
+      :any ->
+        {:ok, elements}
+      true ->
+        {:ok, Enum.filter(elements, &(Element.visible?(&1)))}
+      false ->
+        {:ok, Enum.reject(elements, &(Element.visible?(&1)))}
+    end
   end
 
   defp validate_selected(query, elements) do

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -106,7 +106,7 @@ defmodule Wallaby.Query do
   @type conditions :: [
     count: non_neg_integer,
     text: String.t,
-    visible: boolean(),
+    visible: boolean() | :any,
     selected: boolean() | :any,
     minimum: non_neg_integer,
     at: pos_integer
@@ -395,7 +395,7 @@ defmodule Wallaby.Query do
     cond do
       query.conditions[:minimum] > query.conditions[:maximum] ->
         {:error, :min_max}
-      !Query.visible?(query) && Query.inner_text(query) ->
+      (Query.visible?(query) != true) && Query.inner_text(query) ->
         {:error, :cannot_set_text_with_invisible_elements}
       true ->
         {:ok, query}

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -189,10 +189,10 @@ defmodule Wallaby.Query.ErrorMessage do
   @spec visibility(Query.t) :: String.t
 
   def visibility(query) do
-    if Query.visible?(query) do
-      "visible"
-    else
-      "invisible"
+    case Query.visible?(query) do
+      true -> "visible"
+      false -> "invisible"
+      :any -> "visible or invisible"
     end
   end
 


### PR DESCRIPTION
There are situations where we might not care if the element is visible or not. Additionally, in some corner cases Safari 11 reports different visibility than other browsers. By adding a `visible: :any` option to Query we can support such situations, and optimize our tests to avoid checking visibility when it's not necessary.