### PR TITLE
Handle Safari 11 and Edge 17 stale reference error

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -77,11 +77,16 @@ defmodule Wallaby.HTTPClient do
     end
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp check_for_response_errors(response) do
     case Map.get(response, "value") do
       %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
         {:error, :stale_reference}
+      %{"message" => "Stale element reference" <> _} ->
+        {:error, :stale_reference}
       %{"message" => "stale element reference" <> _} ->
+        {:error, :stale_reference}
+      %{"message" => "An element command failed because the referenced element is no longer available" <> _} ->
         {:error, :stale_reference}
       %{"message" => "invalid selector" <> _} ->
         {:error, :invalid_selector}


### PR DESCRIPTION
Edge 17 responds with: "Stale element..." (uppercase S)
Safari 11 responds with: "An element command failed..."