### PR TITLE
Interacting with opened windows

### DIFF
--- a/integration_test/cases/browser/window_handles_test.exs
+++ b/integration_test/cases/browser/window_handles_test.exs
@@ -26,13 +26,46 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
     |> click(Query.link("New window"))
     :timer.sleep(200)
 
-    handles = window_handles(session)
-    assert length(handles) == 3
+    handles2 = window_handles(session)
+    assert length(handles2) == 3
 
-    new_window_handle = Enum.find(handles, fn handle -> handle not in [initial_handle, new_tab_handle] end)
+    new_window_handle = Enum.find(handles2, fn handle -> handle not in [initial_handle, new_tab_handle] end)
     focus_window(session, new_window_handle)
 
     assert new_window_handle == window_handle(session)
     assert_has(session, Query.css("h1", text: "Page 2"))
+  end
+
+  test "closing tabs and windows", %{session: session} do
+    session
+    |> visit("windows.html")
+
+    initial_handle = window_handle(session)
+
+    session
+    |> click(Query.link("New tab"))
+    :timer.sleep(200)
+
+    new_tab_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
+
+    session
+    |> focus_window(new_tab_handle)
+    |> close_window()
+    |> focus_window(initial_handle)
+
+    assert [initial_handle] == window_handles(session)
+
+    session
+    |> click(Query.link("New window"))
+    :timer.sleep(200)
+
+    new_window_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
+
+    session
+    |> focus_window(new_window_handle)
+    |> close_window()
+    |> focus_window(initial_handle)
+
+    assert [initial_handle] == window_handles(session)
   end
 end

--- a/integration_test/cases/browser/window_handles_test.exs
+++ b/integration_test/cases/browser/window_handles_test.exs
@@ -10,7 +10,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New tab"))
-    :timer.sleep(200)
+    :timer.sleep(500)
 
     handles = window_handles(session)
     assert length(handles) == 2
@@ -24,7 +24,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
     session
     |> focus_window(initial_handle)
     |> click(Query.link("New window"))
-    :timer.sleep(200)
+    :timer.sleep(500)
 
     handles2 = window_handles(session)
     assert length(handles2) == 3
@@ -44,7 +44,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New tab"))
-    :timer.sleep(200)
+    :timer.sleep(500)
 
     new_tab_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
 
@@ -57,7 +57,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New window"))
-    :timer.sleep(200)
+    :timer.sleep(500)
 
     new_window_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
 

--- a/integration_test/cases/browser/window_handles_test.exs
+++ b/integration_test/cases/browser/window_handles_test.exs
@@ -1,0 +1,38 @@
+defmodule Wallaby.Integration.Browser.WindowHandlesTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  test "switching between tabs and windows", %{session: session} do
+    session
+    |> visit("windows.html")
+
+    initial_handle = window_handle(session)
+    assert [initial_handle] == window_handles(session)
+
+    session
+    |> click(Query.link("New tab"))
+    :timer.sleep(200)
+
+    handles = window_handles(session)
+    assert length(handles) == 2
+
+    new_tab_handle = Enum.find(handles, fn handle -> handle != initial_handle end)
+    focus_window(session, new_tab_handle)
+
+    assert new_tab_handle == window_handle(session)
+    assert_has(session, Query.css("h1", text: "Page 1"))
+
+    session
+    |> focus_window(initial_handle)
+    |> click(Query.link("New window"))
+    :timer.sleep(200)
+
+    handles = window_handles(session)
+    assert length(handles) == 3
+
+    new_window_handle = Enum.find(handles, fn handle -> handle not in [initial_handle, new_tab_handle] end)
+    focus_window(session, new_window_handle)
+
+    assert new_window_handle == window_handle(session)
+    assert_has(session, Query.css("h1", text: "Page 2"))
+  end
+end

--- a/integration_test/cases/browser/window_position_test.exs
+++ b/integration_test/cases/browser/window_position_test.exs
@@ -1,0 +1,13 @@
+defmodule Wallaby.Integration.Browser.WindowPositionTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  test "getting the window position", %{session: session} do
+    window_position =
+      session
+      |> visit("/")
+      |> move_window(100, 200)
+      |> window_position()
+
+    assert %{"x" => 100, "y" => 200} = window_position
+  end
+end

--- a/integration_test/cases/browser/window_size_test.exs
+++ b/integration_test/cases/browser/window_size_test.exs
@@ -13,13 +13,12 @@ defmodule Wallaby.Integration.Browser.WindowSizeTest do
 
   describe "default window size" do
     setup do
-      inject_test_session(%{skip_test_session: true})
-
       {:ok, session} = start_test_session(window_size: [width: 600, height: 400])
 
       {:ok, %{session: session}}
     end
 
+    @tag :skip_test_session
     test "sets window size from config option", %{session: session} do
       window_size =
         session

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -5,3 +5,4 @@ Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
+Code.require_file "../cases/browser/window_handles_test.exs", __DIR__

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -6,3 +6,4 @@ Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
 Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
+Code.require_file "../cases/browser/window_position_test.exs", __DIR__

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -3,3 +3,4 @@ Code.require_file "../tests.exs", __DIR__
 # Additional test cases supported by selenium
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
+Code.require_file "../cases/browser/window_handles_test.exs", __DIR__

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -4,3 +4,4 @@ Code.require_file "../tests.exs", __DIR__
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
 Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
+Code.require_file "../cases/browser/window_position_test.exs", __DIR__

--- a/integration_test/support/pages/windows.html
+++ b/integration_test/support/pages/windows.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<head>
+  <title>Windows</title>
+</head>
+
+<body>
+  <a href="page_1.html" rel="noopener noreferrer" target="_blank">New tab or window link</a>
+  <a href="page_2.html" onclick="window.open('page_2.html', 'newwindow', 'width=600,height=400'); return false;">New
+    window link</a>
+</body>
+
+</html>

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -261,11 +261,6 @@ defmodule Wallaby.Browser do
     size
   end
 
-  def window_size(%Session{driver: driver} = session, window_handle) do
-    {:ok, size} = driver.get_window_size(session, window_handle)
-    size
-  end
-
   @doc """
   Sets the size of the sessions window.
   """
@@ -276,18 +271,8 @@ defmodule Wallaby.Browser do
     session
   end
 
-  def resize_window(%Session{driver: driver} = session, window_handle, width, height) do
-    {:ok, _} = driver.set_window_size(session, window_handle, width, height)
-    session
-  end
-
   def maximize_window(%Session{driver: driver} = session) do
     {:ok, _} = driver.maximize_window(session)
-    session
-  end
-
-  def maximize_window(%Session{driver: driver} = session, window_handle) do
-    {:ok, _} = driver.maximize_window(session, window_handle)
     session
   end
 
@@ -296,18 +281,8 @@ defmodule Wallaby.Browser do
     position
   end
 
-  def window_position(%Session{driver: driver} = session, window_handle) do
-    {:ok, position} = driver.get_window_position(session, window_handle)
-    position
-  end
-
   def move_window(%Session{driver: driver} = session, x, y) do
     {:ok, _} = driver.set_window_position(session, x, y)
-    session
-  end
-
-  def move_window(%Session{driver: driver} = session, window_handle, x, y) do
-    {:ok, _} = driver.set_window_position(session, window_handle, x, y)
     session
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -247,6 +247,11 @@ defmodule Wallaby.Browser do
     session
   end
 
+  def close_window(%Session{driver: driver} = session) do
+    {:ok, _} = driver.close_window(session)
+    session
+  end
+
   @doc """
   Gets the size of the session's window.
   """
@@ -257,6 +262,11 @@ defmodule Wallaby.Browser do
     size
   end
 
+  def window_size(%Session{driver: driver} = session, window_handle) do
+    {:ok, size} = driver.get_window_size(session, window_handle)
+    size
+  end
+
   @doc """
   Sets the size of the sessions window.
   """
@@ -264,6 +274,41 @@ defmodule Wallaby.Browser do
 
   def resize_window(%Session{driver: driver} = session, width, height) do
     {:ok, _} = driver.set_window_size(session, width, height)
+    session
+  end
+
+  def resize_window(%Session{driver: driver} = session, window_handle, width, height) do
+    {:ok, _} = driver.set_window_size(session, window_handle, width, height)
+    session
+  end
+
+  def maximize_window(%Session{driver: driver} = session) do
+    {:ok, _} = driver.maximize_window(session)
+    session
+  end
+
+  def maximize_window(%Session{driver: driver} = session, window_handle) do
+    {:ok, _} = driver.maximize_window(session, window_handle)
+    session
+  end
+
+  def window_position(%Session{driver: driver} = session) do
+    {:ok, position} = driver.get_window_position(session)
+    position
+  end
+
+  def window_position(%Session{driver: driver} = session, window_handle) do
+    {:ok, position} = driver.get_window_position(session, window_handle)
+    position
+  end
+
+  def move_window(%Session{driver: driver} = session, x, y) do
+    {:ok, _} = driver.set_window_position(session, x, y)
+    session
+  end
+
+  def move_window(%Session{driver: driver} = session, window_handle, x, y) do
+    {:ok, _} = driver.set_window_position(session, window_handle, x, y)
     session
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -231,57 +231,95 @@ defmodule Wallaby.Browser do
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
   end
 
-  def window_handle(%Session{driver: driver} = session) do
+  @doc """
+  Gets the window handle of the currently focused window.
+  """
+  @spec window_handle(parent) :: String.t
+
+  def window_handle(%{driver: driver} = session) do
     {:ok, handle} = driver.window_handle(session)
     handle
   end
 
-  def window_handles(%Session{driver: driver} = session) do
+  @doc """
+  Gets the window handles of all available windows.
+  """
+  @spec window_handles(parent) :: [String.t]
+
+  def window_handles(%{driver: driver} = session) do
     {:ok, handles} = driver.window_handles(session)
     handles
   end
 
-  def focus_window(%Session{driver: driver} = session, window_handle) do
+
+  @doc """
+  Changes the driver focus to the window identified by the handle.
+  """
+  @spec focus_window(parent, String.t) :: parent
+
+  def focus_window(%{driver: driver} = session, window_handle) do
     {:ok, _} = driver.focus_window(session, window_handle)
     session
   end
 
-  def close_window(%Session{driver: driver} = session) do
+  @doc """
+  Closes the currently focused window.
+  """
+  @spec close_window(parent) :: parent
+
+  def close_window(%{driver: driver} = session) do
     {:ok, _} = driver.close_window(session)
     session
   end
 
   @doc """
-  Gets the size of the session's window.
+  Gets the size of the currently focused window.
   """
   @spec window_size(parent) :: %{String.t => pos_integer, String.t => pos_integer}
 
-  def window_size(%Session{driver: driver} = session) do
+  def window_size(%{driver: driver} = session) do
     {:ok, size} = driver.get_window_size(session)
     size
   end
 
   @doc """
-  Sets the size of the sessions window.
+  Sets the size of the currenty focused window.
   """
   @spec resize_window(parent, pos_integer, pos_integer) :: parent
 
-  def resize_window(%Session{driver: driver} = session, width, height) do
+  def resize_window(%{driver: driver} = session, width, height) do
     {:ok, _} = driver.set_window_size(session, width, height)
     session
   end
 
-  def maximize_window(%Session{driver: driver} = session) do
+  @doc """
+  Maximizes the currenty focused window.
+
+  For most browsers, this requires a window manager to be running.
+  """
+  @spec maximize_window(parent) :: parent
+
+  def maximize_window(%{driver: driver} = session) do
     {:ok, _} = driver.maximize_window(session)
     session
   end
 
-  def window_position(%Session{driver: driver} = session) do
+  @doc """
+  Gets the position of the currently focused window.
+  """
+  @spec window_position(parent) :: %{String.t => pos_integer, String.t => pos_integer}
+
+  def window_position(%{driver: driver} = session) do
     {:ok, position} = driver.get_window_position(session)
     position
   end
 
-  def move_window(%Session{driver: driver} = session, x, y) do
+  @doc """
+  Sets the position of the currenty focused window.
+  """
+  @spec move_window(parent, pos_integer, pos_integer) :: parent
+
+  def move_window(%{driver: driver} = session, x, y) do
     {:ok, _} = driver.set_window_position(session, x, y)
     session
   end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -251,7 +251,6 @@ defmodule Wallaby.Browser do
     handles
   end
 
-
   @doc """
   Changes the driver focus to the window identified by the handle.
   """

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -231,7 +231,6 @@ defmodule Wallaby.Browser do
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
   end
 
-
   def window_handle(%Session{driver: driver} = session) do
     {:ok, handle} = driver.window_handle(session)
     handle

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -171,7 +171,7 @@ defmodule Wallaby.Browser do
       |> fill_in(Query.css("#password_field", with: "secret42"))
 
   ### Note
-  
+
   Currently, ChromeDriver only supports [BMP Unicode](http://www.unicode.org/roadmaps/bmp/) characters. Emojis are [SMP](https://www.unicode.org/roadmaps/smp/) characters and will be ignored by ChromeDriver.
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.
@@ -229,6 +229,22 @@ defmodule Wallaby.Browser do
     end
 
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
+  end
+
+
+  def window_handle(%Session{driver: driver} = session) do
+    {:ok, handle} = driver.window_handle(session)
+    handle
+  end
+
+  def window_handles(%Session{driver: driver} = session) do
+    {:ok, handles} = driver.window_handles(session)
+    handles
+  end
+
+  def focus_window(%Session{driver: driver} = session, window_handle) do
+    {:ok, _} = driver.focus_window(session, window_handle)
+    session
   end
 
   @doc """
@@ -323,7 +339,7 @@ defmodule Wallaby.Browser do
       iex> Wallaby.Session.send_keys(session, [:shift, :enter])
 
   ### Note
-  
+
   Currently, ChromeDriver only supports [BMP Unicode](http://www.unicode.org/roadmaps/bmp/) characters. Emojis are [SMP](https://www.unicode.org/roadmaps/smp/) characters and will be ignored by ChromeDriver.
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -78,29 +78,14 @@ defmodule Wallaby.Driver do
   @callback get_window_position(Session.t) :: {:ok, window_position} | {:error, reason}
 
   @doc """
-  Invoked to retrieve the position of the window identified by the handle.
-  """
-  @callback get_window_position(Session.t, String.t) :: {:ok, window_position} | {:error, reason}
-
-  @doc """
   Invoked to retrieve the size of the currently focused window.
   """
   @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
 
   @doc """
-  Invoked to retrieve the size of the window identified by the handle.
-  """
-  @callback get_window_size(Session.t, String.t) :: {:ok, window_dimension} | {:error, reason}
-
-  @doc """
   Invoked to maximize the currently focused window.
   """
   @callback maximize_window(Session.t) :: {:ok, any} | {:error, reason}
-
-  @doc """
-  Invoked to maximize the window identified by the handle.
-  """
-  @callback maximize_window(Session.t, String.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
@@ -123,21 +108,9 @@ defmodule Wallaby.Driver do
   @callback set_window_size(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
 
   @doc """
-  Invoked to set the size of the window identified by the handle.
-  """
-  @callback set_window_size(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} |
-    {:error, reason}
-
-  @doc """
   Invoked to set the position of the currently focused window.
   """
   @callback set_window_position(Session.t, pos_integer, pos_integer) :: {:ok, any} |
-    {:error, reason}
-
-  @doc """
-  Invoked to set the position of the window identified by the handle.
-  """
-  @callback set_window_position(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} |
     {:error, reason}
 
   @doc """

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -62,9 +62,14 @@ defmodule Wallaby.Driver do
   @callback dismiss_prompt(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
 
   @doc """
-  Invoked to retrieve the size of the window.
+  Invoked to retrieve the size of the currently focused window.
   """
   @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the size of the currently identified by the handle.
+  """
+  @callback get_window_size(Session.t, String.t) :: {:ok, window_dimension} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
@@ -82,9 +87,14 @@ defmodule Wallaby.Driver do
   @callback set_cookie(Session.t, String.t, String.t) :: {:ok, any} | {:error, reason}
 
   @doc """
-  Invoked to set the size of the window.
+  Invoked to set the size of the currently focused window.
   """
   @callback set_window_size(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to set the size of the window identified by the handle.
+  """
+  @callback set_window_size(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to visit a url.

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -40,7 +40,7 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to close the currently focused window.
   """
-  @callback close_window(Session.t) :: {:ok, any} | {:error, reason}
+  @callback close_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve cookies for the given session.
@@ -70,22 +70,22 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to change the driver focus to window specified by handle.
   """
-  @callback focus_window(Session.t, String.t) :: {:ok, any} | {:error, reason}
+  @callback focus_window(Session.t | Element.t, String.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the position of the currently focused window.
   """
-  @callback get_window_position(Session.t) :: {:ok, window_position} | {:error, reason}
+  @callback get_window_position(Session.t | Element.t) :: {:ok, window_position} | {:error, reason}
 
   @doc """
   Invoked to retrieve the size of the currently focused window.
   """
-  @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
+  @callback get_window_size(Session.t | Element.t) :: {:ok, window_dimension} | {:error, reason}
 
   @doc """
   Invoked to maximize the currently focused window.
   """
-  @callback maximize_window(Session.t) :: {:ok, any} | {:error, reason}
+  @callback maximize_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
@@ -105,12 +105,12 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to set the size of the currently focused window.
   """
-  @callback set_window_size(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_size(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to set the position of the currently focused window.
   """
-  @callback set_window_position(Session.t, pos_integer, pos_integer) :: {:ok, any} |
+  @callback set_window_position(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
     {:error, reason}
 
   @doc """
@@ -180,10 +180,10 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to get the handle for the currently focused window.
   """
-  @callback window_handle(Session.t) :: {:ok, String.t} | {:error, reason}
+  @callback window_handle(Session.t | Element.t) :: {:ok, String.t} | {:error, reason}
 
   @doc """
   Invoked to get the list of handles for all windows.
   """
-  @callback window_handles(Session.t) :: {:ok, [String.t]} | {:error, reason}
+  @callback window_handles(Session.t | Element.t) :: {:ok, [String.t]} | {:error, reason}
 end

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -125,17 +125,20 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to set the size of the window identified by the handle.
   """
-  @callback set_window_size(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_size(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
 
   @doc """
   Invoked to set the position of the currently focused window.
   """
-  @callback set_window_position(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_position(Session.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
 
   @doc """
   Invoked to set the position of the window identified by the handle.
   """
-  @callback set_window_position(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_position(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
 
   @doc """
   Invoked to visit a url.

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -105,7 +105,8 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to set the size of the currently focused window.
   """
-  @callback set_window_size(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_size(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
 
   @doc """
   Invoked to set the position of the currently focused window.

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -7,6 +7,7 @@ defmodule Wallaby.Driver do
   @type url :: String.t
   @type open_dialog_fn :: ((Session.t) -> any)
   @type window_dimension :: %{String.t => pos_integer, String.t => pos_integer}
+  @type window_position :: %{String.t => pos_integer, String.t => pos_integer}
 
   @type on_start_session :: {:ok, Session.t} | {:error, reason}
 
@@ -37,6 +38,11 @@ defmodule Wallaby.Driver do
     {:ok, [String.t]} | {:error, reason}
 
   @doc """
+  Invoked to close the currently focused window.
+  """
+  @callback close_window(Session.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
   Invoked to retrieve cookies for the given session.
   """
   @callback cookies(Session.t) :: {:ok, [%{String.t => String.t}]} | {:error, reason}
@@ -62,14 +68,39 @@ defmodule Wallaby.Driver do
   @callback dismiss_prompt(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
 
   @doc """
+  Invoked to change the driver focus to window specified by handle.
+  """
+  @callback focus_window(Session.t, String.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the position of the currently focused window.
+  """
+  @callback get_window_position(Session.t) :: {:ok, window_position} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the position of the window identified by the handle.
+  """
+  @callback get_window_position(Session.t, String.t) :: {:ok, window_position} | {:error, reason}
+
+  @doc """
   Invoked to retrieve the size of the currently focused window.
   """
   @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
 
   @doc """
-  Invoked to retrieve the size of the currently identified by the handle.
+  Invoked to retrieve the size of the window identified by the handle.
   """
   @callback get_window_size(Session.t, String.t) :: {:ok, window_dimension} | {:error, reason}
+
+  @doc """
+  Invoked to maximize the currently focused window.
+  """
+  @callback maximize_window(Session.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to maximize the window identified by the handle.
+  """
+  @callback maximize_window(Session.t, String.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
@@ -95,6 +126,16 @@ defmodule Wallaby.Driver do
   Invoked to set the size of the window identified by the handle.
   """
   @callback set_window_size(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to set the position of the currently focused window.
+  """
+  @callback set_window_position(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to set the position of the window identified by the handle.
+  """
+  @callback set_window_position(Session.t, String.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to visit a url.
@@ -159,4 +200,14 @@ defmodule Wallaby.Driver do
   Invoked to take a screenshot of the session/element.
   """
   @callback take_screenshot(Session.t | Element.t) :: binary | {:error, reason}
+
+  @doc """
+  Invoked to get the handle for the currently focused window.
+  """
+  @callback window_handle(Session.t) :: {:ok, String.t} | {:error, reason}
+
+  @doc """
+  Invoked to get the list of handles for all windows.
+  """
+  @callback window_handles(Session.t) :: {:ok, [String.t]} | {:error, reason}
 end

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -127,27 +127,11 @@ defmodule Wallaby.Experimental.Chrome do
     end
   end
 
-  def get_window_size(%Session{} = session) do
-    delegate(:get_window_size, session, [])
-  end
-
-  def set_window_size(session, width, height) do
-    delegate(:set_window_size, session, [width, height])
-  end
-
   defp delegate(fun, element_or_session, args \\ []) do
     check_logs!(element_or_session, fn ->
       apply(WebdriverClient, fun, [element_or_session | args])
     end)
   end
-
-  defdelegate window_handle(session), to: WebdriverClient
-  defdelegate window_handles(session), to: WebdriverClient
-  defdelegate focus_window(session, window_handle), to: WebdriverClient
-  defdelegate close_window(session), to: WebdriverClient
-  defdelegate get_window_position(session), to: WebdriverClient
-  defdelegate set_window_position(session, x, y), to: WebdriverClient
-  defdelegate maximize_window(session), to: WebdriverClient
 
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
@@ -157,6 +141,27 @@ defmodule Wallaby.Experimental.Chrome do
   defdelegate dismiss_prompt(session, fun), to: WebdriverClient
   defdelegate parse_log(log), to: Wallaby.Experimental.Chrome.Logger
 
+  @doc false
+  def window_handle(%Session{} = session), do: delegate(:window_handle, session)
+  @doc false
+  def window_handles(%Session{} = session), do: delegate(:window_handles, session)
+  @doc false
+  def focus_window(%Session{} = session, window_handle),
+    do: delegate(:focus_window, session, [window_handle])
+  @doc false
+  def close_window(%Session{} = session), do: delegate(:close_window, session)
+  @doc false
+  def get_window_size(%Session{} = session), do: delegate(:get_window_size, session)
+  @doc false
+  def set_window_size(%Session{} = session, width, height),
+    do: delegate(:set_window_size, session, [width, height])
+  @doc false
+  def get_window_position(%Session{} = session), do: delegate(:get_window_position, session)
+  @doc false
+  def set_window_position(%Session{} = session, x, y),
+    do: delegate(:set_window_position, session, [x, y])
+  @doc false
+  def maximize_window(%Session{} = session), do: delegate(:maximize_window, session)
   @doc false
   def cookies(session), do: delegate(:cookies, session)
   @doc false

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -145,14 +145,9 @@ defmodule Wallaby.Experimental.Chrome do
   defdelegate window_handles(session), to: WebdriverClient
   defdelegate focus_window(session, window_handle), to: WebdriverClient
   defdelegate close_window(session), to: WebdriverClient
-  defdelegate get_window_size(session, window_handle), to: WebdriverClient
-  defdelegate set_window_size(session, window_handle, width, height), to: WebdriverClient
   defdelegate get_window_position(session), to: WebdriverClient
-  defdelegate get_window_position(session, window_handle), to: WebdriverClient
   defdelegate set_window_position(session, x, y), to: WebdriverClient
-  defdelegate set_window_position(session, window_handle, x, y), to: WebdriverClient
   defdelegate maximize_window(session), to: WebdriverClient
-  defdelegate maximize_window(session, window_handle), to: WebdriverClient
 
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -144,6 +144,15 @@ defmodule Wallaby.Experimental.Chrome do
   defdelegate window_handle(session), to: WebdriverClient
   defdelegate window_handles(session), to: WebdriverClient
   defdelegate focus_window(session, window_handle), to: WebdriverClient
+  defdelegate close_window(session), to: WebdriverClient
+  defdelegate get_window_size(session, window_handle), to: WebdriverClient
+  defdelegate set_window_size(session, window_handle, width, height), to: WebdriverClient
+  defdelegate get_window_position(session), to: WebdriverClient
+  defdelegate get_window_position(session, window_handle), to: WebdriverClient
+  defdelegate set_window_position(session, x, y), to: WebdriverClient
+  defdelegate set_window_position(session, window_handle, x, y), to: WebdriverClient
+  defdelegate maximize_window(session), to: WebdriverClient
+  defdelegate maximize_window(session, window_handle), to: WebdriverClient
 
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -128,13 +128,11 @@ defmodule Wallaby.Experimental.Chrome do
   end
 
   def get_window_size(%Session{} = session) do
-    handle = delegate(:window_handle, session)
-    delegate(:get_window_size, session, [handle])
+    delegate(:get_window_size, session, [])
   end
 
   def set_window_size(session, width, height) do
-    handle = delegate(:window_handle, session)
-    delegate(:set_window_size, session, [handle, width, height])
+    delegate(:set_window_size, session, [width, height])
   end
 
   defp delegate(fun, element_or_session, args \\ []) do

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Experimental.Chrome do
 
   @chromedriver_version_regex ~r/^ChromeDriver (\d+)\.(\d+)/
 
-  alias Wallaby.{Session, DependencyError, Metadata}
+  alias Wallaby.{DependencyError, Metadata}
   alias Wallaby.Experimental.Chrome.{Chromedriver}
   alias Wallaby.Experimental.Selenium.WebdriverClient
   import Wallaby.Driver.LogChecker
@@ -142,26 +142,24 @@ defmodule Wallaby.Experimental.Chrome do
   defdelegate parse_log(log), to: Wallaby.Experimental.Chrome.Logger
 
   @doc false
-  def window_handle(%Session{} = session), do: delegate(:window_handle, session)
+  def window_handle(session), do: delegate(:window_handle, session)
   @doc false
-  def window_handles(%Session{} = session), do: delegate(:window_handles, session)
+  def window_handles(session), do: delegate(:window_handles, session)
   @doc false
-  def focus_window(%Session{} = session, window_handle),
-    do: delegate(:focus_window, session, [window_handle])
+  def focus_window(session, window_handle), do: delegate(:focus_window, session, [window_handle])
   @doc false
-  def close_window(%Session{} = session), do: delegate(:close_window, session)
+  def close_window(session), do: delegate(:close_window, session)
   @doc false
-  def get_window_size(%Session{} = session), do: delegate(:get_window_size, session)
+  def get_window_size(session), do: delegate(:get_window_size, session)
   @doc false
-  def set_window_size(%Session{} = session, width, height),
+  def set_window_size(session, width, height),
     do: delegate(:set_window_size, session, [width, height])
   @doc false
-  def get_window_position(%Session{} = session), do: delegate(:get_window_position, session)
+  def get_window_position(session), do: delegate(:get_window_position, session)
   @doc false
-  def set_window_position(%Session{} = session, x, y),
-    do: delegate(:set_window_position, session, [x, y])
+  def set_window_position(session, x, y), do: delegate(:set_window_position, session, [x, y])
   @doc false
-  def maximize_window(%Session{} = session), do: delegate(:maximize_window, session)
+  def maximize_window(session), do: delegate(:maximize_window, session)
   @doc false
   def cookies(session), do: delegate(:cookies, session)
   @doc false

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -141,6 +141,10 @@ defmodule Wallaby.Experimental.Chrome do
     end)
   end
 
+  defdelegate window_handle(session), to: WebdriverClient
+  defdelegate window_handles(session), to: WebdriverClient
+  defdelegate focus_window(session, window_handle), to: WebdriverClient
+
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
   defdelegate accept_confirm(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -80,6 +80,15 @@ defmodule Wallaby.Experimental.Selenium do
   defdelegate window_handle(session), to: WebdriverClient
   defdelegate window_handles(session), to: WebdriverClient
   defdelegate focus_window(session, window_handle), to: WebdriverClient
+  defdelegate close_window(session), to: WebdriverClient
+  defdelegate get_window_size(session, window_handle), to: WebdriverClient
+  defdelegate set_window_size(session, window_handle, width, height), to: WebdriverClient
+  defdelegate get_window_position(session), to: WebdriverClient
+  defdelegate get_window_position(session, window_handle), to: WebdriverClient
+  defdelegate set_window_position(session, x, y), to: WebdriverClient
+  defdelegate set_window_position(session, window_handle, x, y), to: WebdriverClient
+  defdelegate maximize_window(session), to: WebdriverClient
+  defdelegate maximize_window(session, window_handle), to: WebdriverClient
 
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -81,14 +81,9 @@ defmodule Wallaby.Experimental.Selenium do
   defdelegate window_handles(session), to: WebdriverClient
   defdelegate focus_window(session, window_handle), to: WebdriverClient
   defdelegate close_window(session), to: WebdriverClient
-  defdelegate get_window_size(session, window_handle), to: WebdriverClient
-  defdelegate set_window_size(session, window_handle, width, height), to: WebdriverClient
   defdelegate get_window_position(session), to: WebdriverClient
-  defdelegate get_window_position(session, window_handle), to: WebdriverClient
   defdelegate set_window_position(session, x, y), to: WebdriverClient
-  defdelegate set_window_position(session, window_handle, x, y), to: WebdriverClient
   defdelegate maximize_window(session), to: WebdriverClient
-  defdelegate maximize_window(session, window_handle), to: WebdriverClient
 
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -102,8 +102,7 @@ defmodule Wallaby.Experimental.Selenium do
   end
 
   def get_window_size(%Session{} = session) do
-    handle = WebdriverClient.window_handle(session)
-    WebdriverClient.get_window_size(session, handle)
+    WebdriverClient.get_window_size(session)
   end
 
   def page_source(%Session{} = session) do
@@ -119,8 +118,7 @@ defmodule Wallaby.Experimental.Selenium do
   end
 
   def set_window_size(%Session{} = session, width, height) do
-    handle = WebdriverClient.window_handle(session)
-    WebdriverClient.set_window_size(session, handle, width, height)
+    WebdriverClient.set_window_size(session, width, height)
   end
 
   def visit(%Session{} = session, path) do

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -77,6 +77,10 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
+  defdelegate window_handle(session), to: WebdriverClient
+  defdelegate window_handles(session), to: WebdriverClient
+  defdelegate focus_window(session, window_handle), to: WebdriverClient
+
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
   defdelegate accept_confirm(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -81,6 +81,8 @@ defmodule Wallaby.Experimental.Selenium do
   defdelegate window_handles(session), to: WebdriverClient
   defdelegate focus_window(session, window_handle), to: WebdriverClient
   defdelegate close_window(session), to: WebdriverClient
+  defdelegate get_window_size(session), to: WebdriverClient
+  defdelegate set_window_size(session, width, height), to: WebdriverClient
   defdelegate get_window_position(session), to: WebdriverClient
   defdelegate set_window_position(session, x, y), to: WebdriverClient
   defdelegate maximize_window(session), to: WebdriverClient
@@ -109,10 +111,6 @@ defmodule Wallaby.Experimental.Selenium do
     WebdriverClient.current_url(session)
   end
 
-  def get_window_size(%Session{} = session) do
-    WebdriverClient.get_window_size(session)
-  end
-
   def page_source(%Session{} = session) do
     WebdriverClient.page_source(session)
   end
@@ -123,10 +121,6 @@ defmodule Wallaby.Experimental.Selenium do
 
   def set_cookie(%Session{} = session, key, value) do
     WebdriverClient.set_cookie(session, key, value)
-  end
-
-  def set_window_size(%Session{} = session, width, height) do
-    WebdriverClient.set_window_size(session, width, height)
   end
 
   def visit(%Session{} = session, path) do

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -428,7 +428,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   @doc """
-  Closes the current window (or tab)
+  Closes the currently focused window (or tab)
   """
   @spec close_window(Session.t) :: {:ok, map}
   def close_window(session) do

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -366,6 +366,16 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
       do: value
   end
 
+  @doc """
+  Changes focus to specified window
+  """
+  @spec focus_window(Session.t(), String.t()) :: :ok
+  def focus_window(session, window_handle) do
+    with {:ok, _resp} <-
+           request(:post, "#{session.url}/window", %{handle: window_handle, name: window_handle}),
+         do: :ok
+  end
+
   @spec cast_as_element(Session.t | Element.t, map) :: Element.t
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
     cast_as_element(parent, %{@web_element_identifier => id})

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -304,6 +304,30 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
       do: {:ok, value}
   end
 
+
+  @doc """
+  Sets the position of the window.
+  """
+  @spec set_window_position(Session.t, non_neg_integer, non_neg_integer) :: :ok
+  @spec set_window_position(Session.t, String.t, non_neg_integer, non_neg_integer) :: :ok
+
+  def set_window_position(session, window_handle \\ "current", x_coordinate, y_coordinate) do
+    with {:ok, _resp} <- request(:post, "#{session.url}/window/#{window_handle}/size", %{x: x_coordinate, y: y_coordinate}),
+      do: :ok
+  end
+
+  @doc """
+  Gets the position of the window.
+  """
+  @spec get_window_position(Session.t) :: {non_neg_integer, non_neg_integer}
+  @spec get_window_position(Session.t, String.t) :: {non_neg_integer, non_neg_integer}
+
+  def get_window_position(session, window_handle \\ "current") do
+    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/size"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {value["x"], value["y"]}
+  end
+
   @doc """
   Executes javascript synchoronously, taking as arguments the script to execute,
   and optionally a list of arguments available in the script via `arguments`

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -329,6 +329,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   @doc """
+  Maximizes the window.
+  """
+  @spec maximize_window(Session.t) :: :ok
+  @spec maximize_window(Session.t, String.t) :: :ok
+
+  def maximize_window(session, window_handle \\ "current") do
+    with {:ok, _resp} <- request(:post, "#{session.url}/window/#{window_handle}/maximize"),
+      do: :ok
+  end
+
+  @doc """
   Executes javascript synchoronously, taking as arguments the script to execute,
   and optionally a list of arguments available in the script via `arguments`
   """

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -376,6 +376,16 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
          do: :ok
   end
 
+  @doc """
+  Closes the current window
+  """
+  @spec close_window(Session.t()) :: :ok
+  def close_window(session) do
+    with {:ok, _resp} <-
+           request(:delete, "#{session.url}/window"),
+         do: :ok
+  end
+
   @spec cast_as_element(Session.t | Element.t, map) :: Element.t
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
     cast_as_element(parent, %{@web_element_identifier => id})

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -274,74 +274,51 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
 
   @doc """
   Sets the size of the window
-
-  If the window_handle argument is not provided, the currently focused window
-  will be resized.
   """
   @spec set_window_size(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
-  @spec set_window_size(Session.t, String.t, non_neg_integer, non_neg_integer) :: {:ok, map}
-  def set_window_size(session, window_handle \\ "current", width, height) do
-    with {:ok, resp} <- request(:post, "#{session.url}/window/#{window_handle}/size", %{width: width, height: height}),
+  def set_window_size(session, width, height) do
+    with {:ok, resp} <- request(:post, "#{session.url}/window/current/size", %{width: width, height: height}),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end
 
   @doc """
   Gets the size of the window
-
-  If the window_handle argument is not provided, the size of the currently focused window
-  will be returned.
   """
   @spec get_window_size(Session.t) :: {:ok, map}
-  @spec get_window_size(Session.t, String.t) :: {:ok, map}
-
-  def get_window_size(session, window_handle \\ "current") do
-    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/size"),
+  def get_window_size(session) do
+    with {:ok, resp} <- request(:get, "#{session.url}/window/current/size"),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end
 
   @doc """
   Changes the position of the window
-
-  If the window_handle argument is not provided, the currently focused window will be moved.
   """
   @spec set_window_position(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
-  @spec set_window_position(Session.t, String.t, non_neg_integer, non_neg_integer) :: {:ok, map()}
-
-  def set_window_position(session, window_handle \\ "current", x_coordinate, y_coordinate) do
+  def set_window_position(session, x_coordinate, y_coordinate) do
     with {:ok, resp} <-
-           request(:post, "#{session.url}/window/#{window_handle}/position", %{x: x_coordinate, y: y_coordinate}),
+           request(:post, "#{session.url}/window/current/position", %{x: x_coordinate, y: y_coordinate}),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end
 
   @doc """
   Gets the position of the window
-
-  If the window_handle argument is not provided, the position of the currently focused window
-  will be returned.
   """
   @spec get_window_position(Session.t) :: {:ok, map}
-  @spec get_window_position(Session.t, String.t) :: {:ok, map}
-
-  def get_window_position(session, window_handle \\ "current") do
-    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/position"),
+  def get_window_position(session) do
+    with {:ok, resp} <- request(:get, "#{session.url}/window/current/position"),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end
 
   @doc """
   Maximizes the window if not already maximized.
-
-  If the window_handle argument is not provided, the currently focused window
-  will be maximized.
   """
   @spec maximize_window(Session.t) :: {:ok, map}
-  @spec maximize_window(Session.t, String.t) :: {:ok, map}
-
-  def maximize_window(session, window_handle \\ "current") do
-    with {:ok, resp} <- request(:post, "#{session.url}/window/#{window_handle}/maximize"),
+  def maximize_window(session) do
+    with {:ok, resp} <- request(:post, "#{session.url}/window/current/maximize"),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -421,8 +421,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   """
   @spec focus_window(Session.t, String.t) :: {:ok, map}
   def focus_window(session, window_handle_or_name) do
-    with {:ok, resp} <- request(:post, "#{session.url}/window", %{name: window_handle_or_name}),
-          # do we need to add `handle: window_handle` ?
+    with {:ok, resp} <- request(:post, "#{session.url}/window", %{name: window_handle_or_name, handle: window_handle_or_name}),
+          # without :handle it doesn't work in firefox
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -309,7 +309,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @spec set_window_position(Session.t(), String.t(), non_neg_integer(), non_neg_integer()) :: :ok
 
   def set_window_position(session, window_handle \\ "current", x_coordinate, y_coordinate) do
-    with {:ok, _resp} <- request(:post, "#{session.url}/window/#{window_handle}/size", %{x: x_coordinate, y: y_coordinate}),
+    with {:ok, _resp} <- request(:post, "#{session.url}/window/#{window_handle}/position", %{x: x_coordinate, y: y_coordinate}),
       do: :ok
   end
 
@@ -323,7 +323,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @spec get_window_position(Session.t(), String.t()) :: {:ok, map()}
 
   def get_window_position(session, window_handle \\ "current") do
-    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/size"),
+    with {:ok, resp} <- request(:get, "#{session.url}/window/#{window_handle}/position"),
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -275,7 +275,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Sets the size of the window
 
-  If the window_handle argument is not provided, the currently active window
+  If the window_handle argument is not provided, the currently focused window
   will be resized.
   """
   @spec set_window_size(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
@@ -289,7 +289,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Gets the size of the window
 
-  If the window_handle argument is not provided, the size of the currently active window
+  If the window_handle argument is not provided, the size of the currently focused window
   will be returned.
   """
   @spec get_window_size(Session.t) :: {:ok, map}
@@ -304,7 +304,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Changes the position of the window
 
-  If the window_handle argument is not provided, the currently active window will be moved.
+  If the window_handle argument is not provided, the currently focused window will be moved.
   """
   @spec set_window_position(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
   @spec set_window_position(Session.t, String.t, non_neg_integer, non_neg_integer) :: {:ok, map()}
@@ -319,7 +319,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Gets the position of the window
 
-  If the window_handle argument is not provided, the position of the currently active window
+  If the window_handle argument is not provided, the position of the currently focused window
   will be returned.
   """
   @spec get_window_position(Session.t) :: {:ok, map}
@@ -334,7 +334,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Maximizes the window if not already maximized.
 
-  If the window_handle argument is not provided, the currently active window
+  If the window_handle argument is not provided, the currently focused window
   will be maximized.
   """
   @spec maximize_window(Session.t) :: {:ok, map}

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -8,6 +8,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
 
   @type http_method :: :post | :get | :delete
   @type url :: String.t
+  @type parent :: Element.t
+                | Session.t
 
   @web_element_identifier "element-6066-11e4-a52e-4f735466cecf"
 
@@ -275,7 +277,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Sets the size of the window
   """
-  @spec set_window_size(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
+  @spec set_window_size(parent, non_neg_integer, non_neg_integer) :: {:ok, map}
   def set_window_size(session, width, height) do
     with {:ok, resp} <- request(:post, "#{session.url}/window/current/size", %{width: width, height: height}),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -285,7 +287,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Gets the size of the window
   """
-  @spec get_window_size(Session.t) :: {:ok, map}
+  @spec get_window_size(parent) :: {:ok, map}
   def get_window_size(session) do
     with {:ok, resp} <- request(:get, "#{session.url}/window/current/size"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -295,7 +297,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Changes the position of the window
   """
-  @spec set_window_position(Session.t, non_neg_integer, non_neg_integer) :: {:ok, map}
+  @spec set_window_position(parent, non_neg_integer, non_neg_integer) :: {:ok, map}
   def set_window_position(session, x_coordinate, y_coordinate) do
     with {:ok, resp} <-
            request(:post, "#{session.url}/window/current/position", %{x: x_coordinate, y: y_coordinate}),
@@ -306,7 +308,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Gets the position of the window
   """
-  @spec get_window_position(Session.t) :: {:ok, map}
+  @spec get_window_position(parent) :: {:ok, map}
   def get_window_position(session) do
     with {:ok, resp} <- request(:get, "#{session.url}/window/current/position"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -316,7 +318,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Maximizes the window if not already maximized.
   """
-  @spec maximize_window(Session.t) :: {:ok, map}
+  @spec maximize_window(parent) :: {:ok, map}
   def maximize_window(session) do
     with {:ok, resp} <- request(:post, "#{session.url}/window/current/maximize"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -373,7 +375,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Retrieves the list of window handles of all windows (or tabs) available to the session
   """
-  @spec window_handles(Session.t) :: {:ok, list(String.t)}
+  @spec window_handles(parent) :: {:ok, list(String.t)}
   def window_handles(session) do
     with {:ok, resp} <- request(:get, "#{session.url}/window_handles"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -383,7 +385,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Retrieves the window handle for the currently focused window (or tab) for the session
   """
-  @spec window_handle(Session.t) :: {:ok, String.t}
+  @spec window_handle(parent) :: {:ok, String.t}
   def window_handle(session) do
     with {:ok, resp} <- request(:get, "#{session.url}/window_handle"),
           {:ok, value} <- Map.fetch(resp, "value"),
@@ -396,7 +398,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   The window to change focus to may be specified by its server assigned
   window handle, or by the value of its name attribute.
   """
-  @spec focus_window(Session.t, String.t) :: {:ok, map}
+  @spec focus_window(parent, String.t) :: {:ok, map}
   def focus_window(session, window_handle_or_name) do
     with {:ok, resp} <- request(:post, "#{session.url}/window",
                                  %{
@@ -417,7 +419,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Closes the currently focused window (or tab)
   """
-  @spec close_window(Session.t) :: {:ok, map}
+  @spec close_window(parent) :: {:ok, map}
   def close_window(session) do
     with {:ok, resp} <- request(:delete, "#{session.url}/window"),
           {:ok, value} <- Map.fetch(resp, "value"),

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -422,7 +422,12 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @spec focus_window(Session.t, String.t) :: {:ok, map}
   def focus_window(session, window_handle_or_name) do
     with {:ok, resp} <- request(:post, "#{session.url}/window", %{name: window_handle_or_name, handle: window_handle_or_name}),
-          # without :handle it doesn't work in firefox
+          # docs say it should be `name:` https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidwindow
+          # official java client has only `handle:` https://github.com/SeleniumHQ/selenium/blob/aa041a8f9ed39014734510c347d307756b179493/java/client/src/org/openqa/selenium/remote/DriverCommand.java#L122
+          # without `handle:` it doesn't work for Firefox
+          # without `name:` it doesn't work for Chrome
+          # in official java client it works for Chrome through a javascript workaround: https://github.com/SeleniumHQ/selenium/blob/96fec3ca49a1462c7881fcd0c06194cb565bdd2d/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#L968
+          # I think we should just keep both params
           {:ok, value} <- Map.fetch(resp, "value"),
       do: {:ok, value}
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -316,7 +316,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   @doc """
-  Maximizes the window if not already maximized.
+  Maximizes the window if not already maximized
   """
   @spec maximize_window(parent) :: {:ok, map}
   def maximize_window(session) do
@@ -395,8 +395,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Changes focus to another window (or tab)
 
-  The window to change focus to may be specified by its server assigned
-  window handle, or by the value of its name attribute.
+  You may specify the the window by its server-assigned window handle
+  or by the value of its name attribute.
   """
   @spec focus_window(parent, String.t) :: {:ok, map}
   def focus_window(session, window_handle_or_name) do

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -209,7 +209,6 @@ defmodule Wallaby.Phantom do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end
 
-
   def window_handle(_session), do: {:error, :not_supported}
   def window_handles(_session), do: {:error, :not_supported}
   def focus_window(_session, _window_handle), do: {:error, :not_supported}

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -208,4 +208,18 @@ defmodule Wallaby.Phantom do
   defp configured_phantom_js do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end
+
+
+  def window_handle(_session), do: {:error, :not_supported}
+  def window_handles(_session), do: {:error, :not_supported}
+  def focus_window(_session, _window_handle), do: {:error, :not_supported}
+  def close_window(_session), do: {:error, :not_supported}
+  def get_window_size(_session, _window_handle), do: {:error, :not_supported}
+  def set_window_size(_session, _window_handle, _width, _height), do: {:error, :not_supported}
+  def get_window_position(_session), do: {:error, :not_supported}
+  def get_window_position(_session, _window_handle), do: {:error, :not_supported}
+  def set_window_position(_session, _x, _y), do: {:error, :not_supported}
+  def set_window_position(_session, _window_handle, _x, _y), do: {:error, :not_supported}
+  def maximize_window(_session), do: {:error, :not_supported}
+  def maximize_window(_session, _window_handle), do: {:error, :not_supported}
 end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -213,12 +213,7 @@ defmodule Wallaby.Phantom do
   def window_handles(_session), do: {:error, :not_supported}
   def focus_window(_session, _window_handle), do: {:error, :not_supported}
   def close_window(_session), do: {:error, :not_supported}
-  def get_window_size(_session, _window_handle), do: {:error, :not_supported}
-  def set_window_size(_session, _window_handle, _width, _height), do: {:error, :not_supported}
   def get_window_position(_session), do: {:error, :not_supported}
-  def get_window_position(_session, _window_handle), do: {:error, :not_supported}
   def set_window_position(_session, _x, _y), do: {:error, :not_supported}
-  def set_window_position(_session, _window_handle, _x, _y), do: {:error, :not_supported}
   def maximize_window(_session), do: {:error, :not_supported}
-  def maximize_window(_session, _window_handle), do: {:error, :not_supported}
 end

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -949,7 +949,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       handle_request bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/window"
-        assert conn.body_params == %{"name" => window_handle_id}
+        assert conn.body_params == %{"name" => window_handle_id, "handle" => window_handle_id}
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -603,29 +603,6 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
-  describe "set_window_size/4" do
-    test "sends the correct request to the server", %{bypass: bypass} do
-      session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
-      height = 600
-      width = 400
-
-      handle_request bypass, fn conn ->
-        assert conn.method == "POST"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
-        assert conn.body_params == %{"height" => height, "width" => width}
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
-      end
-
-      assert {:ok, %{}} = Client.set_window_size(session, window_handle_id, width, height)
-    end
-  end
-
   describe "get_window_size/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
@@ -645,29 +622,6 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       end
 
       assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session)
-    end
-  end
-
-  describe "get_window_size/2" do
-    test "sends the correct request to the server", %{bypass: bypass} do
-      session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
-
-      handle_request bypass, fn conn ->
-        assert conn.method == "GET"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {
-            "height": 600,
-            "width": 400
-          }
-        }>)
-      end
-
-      assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session, window_handle_id)
     end
   end
 
@@ -693,29 +647,6 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
-  describe "set_window_position/4" do
-    test "sends the correct request to the server", %{bypass: bypass} do
-      session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
-      x_coordinate = 600
-      y_coordinate = 400
-
-      handle_request bypass, fn conn ->
-        assert conn.method == "POST"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/position"
-        assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
-      end
-
-      assert {:ok, %{}} = Client.set_window_position(session, window_handle_id, x_coordinate, y_coordinate)
-    end
-  end
-
   describe "get_window_position/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
@@ -738,29 +669,6 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
-  describe "get_window_position/2" do
-    test "sends the correct request to the server", %{bypass: bypass} do
-      session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
-
-      handle_request bypass, fn conn ->
-        assert conn.method == "GET"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/position"
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {
-            "x": 600,
-            "y": 400
-          }
-        }>)
-      end
-
-      assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session, window_handle_id)
-    end
-  end
-
   describe "maximize_window/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
@@ -777,26 +685,6 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       end
 
       assert {:ok, %{}} == Client.maximize_window(session)
-    end
-  end
-
-  describe "maximize_window/2" do
-    test "sends the correct request to the server", %{bypass: bypass} do
-      session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
-
-      handle_request bypass, fn conn ->
-        assert conn.method == "POST"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/maximize"
-
-        send_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
-      end
-
-      assert {:ok, %{}} == Client.maximize_window(session, window_handle_id)
     end
   end
 

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -584,6 +584,28 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
   describe "set_window_size/3" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
+      height = 600
+      width = 400
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/current/size"
+        assert conn.body_params == %{"height" => height, "width" => width}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.set_window_size(session, width, height)
+    end
+  end
+
+  describe "set_window_size/4" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
       window_handle_id = "my-window-handle"
       height = 600
       width = 400
@@ -607,6 +629,28 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
   describe "get_window_size/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window/current/size"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {
+            "height": 600,
+            "width": 400
+          }
+        }>)
+      end
+
+      assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session)
+    end
+  end
+
+  describe "get_window_size/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
       window_handle_id = "my-window-handle"
 
       handle_request bypass, fn conn ->
@@ -624,6 +668,135 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       end
 
       assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session, window_handle_id)
+    end
+  end
+
+  describe "set_window_position/3" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      x_coordinate = 600
+      y_coordinate = 400
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/current/position"
+        assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.set_window_position(session, x_coordinate, y_coordinate)
+    end
+  end
+
+  describe "set_window_position/4" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+      x_coordinate = 600
+      y_coordinate = 400
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/position"
+        assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.set_window_position(session, window_handle_id, x_coordinate, y_coordinate)
+    end
+  end
+
+  describe "get_window_position/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window/current/position"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {
+            "x": 600,
+            "y": 400
+          }
+        }>)
+      end
+
+      assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session)
+    end
+  end
+
+  describe "get_window_position/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/position"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {
+            "x": 600,
+            "y": 400
+          }
+        }>)
+      end
+
+      assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session, window_handle_id)
+    end
+  end
+
+  describe "maximize_window/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/current/maximize"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} == Client.maximize_window(session)
+    end
+  end
+
+  describe "maximize_window/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/maximize"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} == Client.maximize_window(session, window_handle_id)
     end
   end
 
@@ -730,6 +903,25 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
+  describe "window_handles/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window_handles"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": ["some-window-handle", "other-window-handle"]
+        }>)
+      end
+
+      assert {:ok, ["some-window-handle", "other-window-handle"]} = Client.window_handles(session)
+    end
+  end
+
   describe "window_handle/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
@@ -745,7 +937,47 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert "my-window-handle" = Client.window_handle(session)
+      assert {:ok, "my-window-handle"} = Client.window_handle(session)
+    end
+  end
+
+  describe "focus_window/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window"
+        assert conn.body_params == %{"name" => window_handle_id}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_window(session, window_handle_id)
+    end
+  end
+
+  describe "close_window/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/session/#{session.id}/window"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.close_window(session)
     end
   end
 


### PR DESCRIPTION
Closes #360

TODO:
- [x] Expose through Selenium, Chrome and Browser modules
- [x] Check no window_handle vs "current" window_handle (spec says it's "current"), possibly change get_window_size and set_window_size to use it as well
- ~~Revisit handling errors, reading the value from the response and return types (`:ok` is just the happy path)~~ that's fine for now I think
- [x] Test in Selenium: Safari 11, Edge 17, Firefox, Chrome, Opera, Appium (older version compatible with this protocol)
- [x] Test in Chromedriver with a few Chrome and Chromium versions
- [x] Add documentation

For the unaware: I'm following the [Selenium WebDriver Wire Protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol). The [W3C WebDriver Protocol](https://w3c.github.io/webdriver/#endpoints) has too many changes to try to support both of them at the same time. We will need to have a separate WebdriverClient module for it for people that want to test in Safari 12 or newer, Edge 18 or newer, new Appium versions etc.