### PR TITLE
Add support for handling JS confirm, alert and prompt in Selenium

### DIFF
--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -1,7 +1,6 @@
 Code.require_file "../tests.exs", __DIR__
 
 # Additional test cases supported by phantom
-Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/phantom/all_test.exs
+++ b/integration_test/phantom/all_test.exs
@@ -1,7 +1,6 @@
 Code.require_file "../tests.exs", __DIR__
 
 # Additional test cases supported by phantom
-Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -10,6 +10,7 @@ Code.require_file "cases/browser/click_button_test.exs", __DIR__
 Code.require_file "cases/browser/click_test.exs", __DIR__
 Code.require_file "cases/browser/cookies_test.exs", __DIR__
 Code.require_file "cases/browser/current_path_test.exs", __DIR__
+Code.require_file "cases/browser/dialog_test.exs", __DIR__
 Code.require_file "cases/browser/execute_script_test.exs", __DIR__
 Code.require_file "cases/browser/fill_in_test.exs", __DIR__
 Code.require_file "cases/browser/find_test.exs", __DIR__

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -77,13 +77,12 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
-  # Dialog handling not supported yet
-  def accept_alert(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_alert(_session, _fun), do: {:error, :not_implemented}
-  def accept_confirm(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_confirm(_session, _fun), do: {:error, :not_implemented}
-  def accept_prompt(_session, _input, _fun), do: {:error, :not_implemented}
-  def dismiss_prompt(_session, _fun), do: {:error, :not_implemented}
+  defdelegate accept_alert(session, fun), to: WebdriverClient
+  defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  defdelegate accept_confirm(session, fun), to: WebdriverClient
+  defdelegate dismiss_confirm(session, fun), to: WebdriverClient
+  defdelegate accept_prompt(session, input, fun), to: WebdriverClient
+  defdelegate dismiss_prompt(session, fun), to: WebdriverClient
 
   # Screenshots don't appear to be supported with Gecko Driver
   def take_screenshot(_session), do: {:error, :not_supported}

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -105,10 +105,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   def dismiss_prompt(session, fun) do
-    fun.(session)
-    with  {:ok, value} <- alert_text(session),
-          {:ok, _resp} <- request(:post, "#{session.url}/alert/dismiss"),
-      do: value
+    dismiss_confirm(session, fun)
   end
 
   @doc """


### PR DESCRIPTION
JS window.alert, window.confirm and window.prompt were handled by Chromedriver and PhantomJS, but for Selenium functions for accept and dismiss them were not implemented.

This PR adds code that allows to use the following functions:

    accept_alert/2,
    accept_confirm/2,
    accept_prompt/2,
    accept_prompt/3,
    dismiss_confirm/2
    dismiss_prompt/2,
    dismiss_alert/2.

To make it work with Firefox as well as Chrome, the `dismiss_prompt/2` endpoint was switched to the one specified by Selenium WebDriver JSON Wire Protocol (instead of the endpoint specified in the W3C WebDriver specification), which is the same as dismiss_confirm/2. This change also affects the Chromedriver backend (since it uses the same WebDriver module as Selenium) but should not cause any regressions.

Since all dialog tests should be now passing on all platforms, `integration_test/cases/browser/dialog_test.exs` was moved to the set of default tests for all drivers.

edit: force-pushed to rebase on current upstream master