### PR TITLE
Add support for taking screenshot in Selenium

### DIFF
--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -1,7 +1,6 @@
 Code.require_file "../tests.exs", __DIR__
 
-# Additional test cases supported by phantom
+# Additional test cases supported by chromedriver
 Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
-Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/phantom/all_test.exs
+++ b/integration_test/phantom/all_test.exs
@@ -4,4 +4,3 @@ Code.require_file "../tests.exs", __DIR__
 Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
-Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -19,6 +19,7 @@ Code.require_file "cases/browser/has_value_test.exs", __DIR__
 Code.require_file "cases/browser/local_storage_test.exs", __DIR__
 Code.require_file "cases/browser/navigation_test.exs", __DIR__
 Code.require_file "cases/browser/page_source_test.exs", __DIR__
+Code.require_file "cases/browser/screenshot_test.exs", __DIR__
 Code.require_file "cases/browser/select_test.exs", __DIR__
 Code.require_file "cases/browser/set_value_test.exs", __DIR__
 Code.require_file "cases/browser/send_text_test.exs", __DIR__

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -85,8 +85,7 @@ defmodule Wallaby.Experimental.Selenium do
   def accept_prompt(_session, _input, _fun), do: {:error, :not_implemented}
   def dismiss_prompt(_session, _fun), do: {:error, :not_implemented}
 
-  # Screenshots don't appear to be supported with Gecko Driver
-  def take_screenshot(_session), do: {:error, :not_supported}
+  defdelegate take_screenshot(session_or_element), to: WebdriverClient
 
   def cookies(%Session{} = session) do
     WebdriverClient.cookies(session)


### PR DESCRIPTION
Similarily to #428, `take_screenshot` was handled by Chromedriver and PhantomJS, but for Selenium functions was not implemented. The comment said

> Screenshots don't appear to be supported with Gecko Driver

but screenshots are working just fine using recent Geckodriver.

Since screenshot tests should be now passing on all platforms, `integration_test/cases/browser/screenshot_test.exs` was moved to the set of default tests for all drivers.