### PR TITLE
increase the jitter from 0-50ms to 250-300ms

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -7,7 +7,7 @@ defmodule Wallaby.HTTPClient do
   @type request_opts :: {:encode_json, boolean}
 
   @status_obscured 13
-  @max_jitter 50 # The maximum time we'll sleep is for 50ms
+  @jitter 250..300 # sleep for between 250-300ms before retrying
 
   @doc """
   Sends a request to the webdriver API and parses the
@@ -117,5 +117,5 @@ defmodule Wallaby.HTTPClient do
     %{using: "css selector", value: css}
   end
 
-  defp jitter, do: :rand.uniform(@max_jitter)
+  defp jitter, do: Enum.random(@jitter)
 end


### PR DESCRIPTION
This PR increases the amount of time between retries. When we attempt to start new chromedriver processes too quickly, we get the following error when running our tests:

```
** (RuntimeError) Wallaby had an internal issue with HTTPoison:
%HTTPoison.Error{id: nil, reason: :econnrefused}
```

Increasing the minimum retry delay to 250ms (this PR), in addition to passing in the following custom `create_session_fn` that uses a [mutex](https://github.com/niahoo/mutex) to enforce a delay between calls to chromedriver, is the only way we can get our project's Wallaby tests to pass when running more than 2 concurrent test processes:

```elixir
def create_session(base_url, capabilities) do
  Mutex.under(:chrome_session_mutex, :start_session, :infinity, fn ->
    :timer.sleep(500)

    Wallaby.Experimental.Selenium.WebdriverClient.create_session(base_url, capabilities)
  end)
end
```
(Passing in this custom `create_session_fn` has the downside of adding 500ms * the number of tests we have... it would be nice to find a way to call chromedriver rapidly and not have it refuse connections.)
