### PR TITLE
Hover

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.7.4
+elixir 1.7.4-otp-20
 erlang 20.0

--- a/integration_test/cases/browser/hover_test.exs
+++ b/integration_test/cases/browser/hover_test.exs
@@ -8,11 +8,11 @@ defmodule Wallaby.Integration.Browser.HoverTest do
   describe "hover/2" do
     test "sends keys to the specified element", %{page: page} do
       refute page
-      |> visible?(Query.text("HI"))
+             |> visible?(Query.text("HI"))
 
       assert page
-      |> hover(Query.css(".group"))
-      |> visible?(Query.text("HI"))
+             |> hover(Query.css(".group"))
+             |> visible?(Query.text("HI"))
     end
   end
 end

--- a/integration_test/cases/browser/hover_test.exs
+++ b/integration_test/cases/browser/hover_test.exs
@@ -1,0 +1,18 @@
+defmodule Wallaby.Integration.Browser.HoverTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  setup %{session: session} do
+    {:ok, page: visit(session, "hover.html")}
+  end
+
+  describe "hover/2" do
+    test "sends keys to the specified element", %{page: page} do
+      refute page
+      |> visible?(Query.text("HI"))
+
+      assert page
+      |> hover(Query.css(".group"))
+      |> visible?(Query.text("HI"))
+    end
+  end
+end

--- a/integration_test/cases/element/hover_test.exs
+++ b/integration_test/cases/element/hover_test.exs
@@ -1,0 +1,22 @@
+defmodule Wallaby.Integration.Element.HoverTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  setup %{session: session} do
+    {:ok, page: visit(session, "hover.html")}
+  end
+
+  describe "hover/2" do
+    test "sends keys to the specified element", %{page: page} do
+      page
+      |> find(Query.text("HI", visible: false), fn el ->
+        refute Element.visible?(el)
+      end)
+      |> find(Query.css(".group"), fn el -> 
+        Element.hover(el)
+      end)
+      |> find(Query.text("HI"), fn el ->
+        assert Element.visible?(el)
+      end)
+    end
+  end
+end

--- a/integration_test/cases/element/hover_test.exs
+++ b/integration_test/cases/element/hover_test.exs
@@ -11,7 +11,7 @@ defmodule Wallaby.Integration.Element.HoverTest do
       |> find(Query.text("HI", visible: false), fn el ->
         refute Element.visible?(el)
       end)
-      |> find(Query.css(".group"), fn el -> 
+      |> find(Query.css(".group"), fn el ->
         Element.hover(el)
       end)
       |> find(Query.text("HI"), fn el ->

--- a/integration_test/support/pages/hover.html
+++ b/integration_test/support/pages/hover.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Test Index</title>
+  </head>
+  <body class="bootstrap index-page">
+    <style>
+      .group {
+        height: 50vh;
+        width: 50vw;
+      }
+
+      .should-hover {
+        display: none;
+      }
+
+      .group:hover .should-hover {
+        display: block;
+      }
+    </style>
+    <div class="group">
+      <div class="should-hover">HI</div>
+    </div>
+  </body>
+</html>

--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -1,4 +1,5 @@
 defmodule Wallaby.Integration.SessionCase do
+  @moduledoc false
   use ExUnit.CaseTemplate
 
   using do
@@ -15,7 +16,8 @@ defmodule Wallaby.Integration.SessionCase do
   """
   def start_test_session(opts \\ []) do
     session_opts =
-      System.get_env("WALLABY_DRIVER")
+      "WALLABY_DRIVER"
+      |> System.get_env()
       |> default_opts_for_driver
       |> Keyword.merge(opts)
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -378,13 +378,23 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Clicks a element.
+  Clicks an element.
   """
   @spec click(parent, Query.t) :: parent
 
   def click(parent, query) do
     parent
     |> find(query, &Element.click/1)
+  end
+
+  @doc """
+  Hovers over an element.
+  """
+  @spec click(parent, Query.t) :: parent
+
+  def hover(parent, query) do
+    parent
+    |> find(query, &Element.hover/1)
   end
 
   @doc """

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -390,7 +390,7 @@ defmodule Wallaby.Browser do
   @doc """
   Hovers over an element.
   """
-  @spec click(parent, Query.t) :: parent
+  @spec hover(parent, Query.t) :: parent
 
   def hover(parent, query) do
     parent

--- a/lib/wallaby/driver/log_store.ex
+++ b/lib/wallaby/driver/log_store.ex
@@ -8,6 +8,10 @@ defmodule Wallaby.Driver.LogStore do
   @doc """
   Appends logs to a session
   """
+  def append_logs(session, logs) when is_binary(session) and not is_list(logs) do
+    append_logs(session, List.wrap(logs))
+  end
+
   def append_logs(session, logs) when is_binary(session) do
     Agent.get_and_update __MODULE__, fn(map) ->
       Map.get_and_update map, session, fn

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -97,6 +97,18 @@ defmodule Wallaby.Element do
   end
 
   @doc """
+  Hovers on the element.
+  """
+  @spec hover(t) :: t
+
+  def hover(%__MODULE__{driver: driver} = element) do
+    case driver.hover(element) do
+      {:ok, _} ->
+        element
+    end
+  end
+
+  @doc """
   Returns the text from the element.
   """
   @spec text(t) :: String.t

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -170,6 +170,8 @@ defmodule Wallaby.Experimental.Chrome do
   @doc false
   def click(element), do: delegate(:click, element)
   @doc false
+  def hover(element), do: delegate(:hover, element)
+  @doc false
   def clear(element), do: delegate(:clear, element)
   @doc false
   def displayed(element), do: delegate(:displayed, element)

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -140,6 +140,10 @@ defmodule Wallaby.Experimental.Selenium do
     WebdriverClient.click(element)
   end
 
+  def hover(%Element{} = element) do
+    WebdriverClient.hover(element)
+  end
+
   def displayed(%Element{} = element) do
     WebdriverClient.displayed(element)
   end

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -119,6 +119,16 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   @doc """
+  Hovers over an element
+  """
+  @spec hover(Element.t) :: {:ok, map}
+  def hover(%Element{session_url: session_url, id: id}) do
+    with  {:ok, resp} <- request(:post, "#{session_url}/moveto", %{"element" => id}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
   Gets the text for an element
   """
   @spec text(Element.t) :: {:ok, String.t}

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -116,59 +116,59 @@ defmodule Wallaby.Phantom do
   end
 
   @doc false
-  defdelegate accept_alert(session, open_dialog_fn),              to: Driver
+  defdelegate accept_alert(session, open_dialog_fn), to: Driver
   @doc false
-  defdelegate accept_confirm(session, open_dialog_fn),            to: Driver
+  defdelegate accept_confirm(session, open_dialog_fn), to: Driver
   @doc false
-  defdelegate accept_prompt(session, input_va, open_dialog_fn),   to: Driver
+  defdelegate accept_prompt(session, input_va, open_dialog_fn), to: Driver
   @doc false
-  defdelegate cookies(session),                                   to: Driver
+  defdelegate cookies(session), to: Driver
   @doc false
-  defdelegate current_path(session),                             to: Driver
+  defdelegate current_path(session), to: Driver
   @doc false
-  defdelegate current_url(session),                              to: Driver
+  defdelegate current_url(session), to: Driver
   @doc false
-  defdelegate dismiss_confirm(session, open_dialog_fn),           to: Driver
+  defdelegate dismiss_confirm(session, open_dialog_fn), to: Driver
   @doc false
-  defdelegate dismiss_prompt(session, open_dialog_fn),            to: Driver
+  defdelegate dismiss_prompt(session, open_dialog_fn), to: Driver
   @doc false
-  defdelegate get_window_size(session),                           to: Driver
+  defdelegate get_window_size(session), to: Driver
   @doc false
-  defdelegate page_title(session),                                to: Driver
+  defdelegate page_title(session), to: Driver
   @doc false
-  defdelegate page_source(session),                               to: Driver
+  defdelegate page_source(session), to: Driver
   @doc false
-  defdelegate set_cookie(session, key, value),                    to: Driver
+  defdelegate set_cookie(session, key, value), to: Driver
   @doc false
-  defdelegate set_window_size(session, width, height),            to: Driver
+  defdelegate set_window_size(session, width, height), to: Driver
   @doc false
-  defdelegate visit(session, url),                                to: Driver
+  defdelegate visit(session, url), to: Driver
 
   @doc false
-  defdelegate attribute(element, name),                           to: Driver
+  defdelegate attribute(element, name), to: Driver
   @doc false
-  defdelegate click(element),                                     to: Driver
+  defdelegate click(element), to: Driver
   @doc false
-  defdelegate clear(element),                                     to: Driver
+  defdelegate clear(element), to: Driver
   @doc false
-  defdelegate displayed(element),                                 to: Driver
+  defdelegate displayed(element), to: Driver
   @doc false
-  defdelegate selected(element),                                  to: Driver
+  defdelegate selected(element), to: Driver
   @doc false
-  defdelegate set_value(element, value),                          to: Driver
+  defdelegate set_value(element, value), to: Driver
   @doc false
-  defdelegate text(element),                                      to: Driver
+  defdelegate text(element), to: Driver
 
   @doc false
-  defdelegate execute_script(session_or_element, script, args),   to: Driver
+  defdelegate execute_script(session_or_element, script, args), to: Driver
   @doc false
-  defdelegate find_elements(session_or_element, compiled_query),  to: Driver
+  defdelegate find_elements(session_or_element, compiled_query), to: Driver
   @doc false
-  defdelegate send_keys(session_or_element, keys),                to: Driver
+  defdelegate send_keys(session_or_element, keys), to: Driver
   @doc false
-  defdelegate take_screenshot(session_or_element),                to: Driver
-  defdelegate log(session_or_element),                            to: Driver
-  defdelegate parse_log(log),                                     to: Wallaby.Phantom.Logger
+  defdelegate take_screenshot(session_or_element), to: Driver
+  defdelegate log(session_or_element), to: Driver
+  defdelegate parse_log(log), to: Wallaby.Phantom.Logger
 
   @doc false
   def user_agent do

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -762,6 +762,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
+          "value": {}
         }>)
       end
 

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -749,6 +749,26 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
+  describe "hover/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      element = build_element_for_session(session)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/moveto"
+        assert conn.body_params == %{"element" => element.id}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.hover(element)
+    end
+  end
+
   defp handle_request(bypass, handler_fn) do
     Bypass.expect bypass, fn conn ->
       conn |> parse_body |> handler_fn.()

--- a/test/wallaby/phantom/log_store_test.exs
+++ b/test/wallaby/phantom/log_store_test.exs
@@ -9,11 +9,20 @@ defmodule Wallaby.Driver.LogStoreTest do
 
   @session "123abc"
 
+  setup do
+    Agent.update(LogStore, fn _ -> Map.new end)
+  end
+
   describe "append_logs/2" do
     test "only appends new logs" do
-      LogStore.start_link
       assert LogStore.append_logs(@session, [@l1, @l2]) == [@l1, @l2]
       assert LogStore.append_logs(@session, [@l2, @l3]) == [@l3]
+      assert LogStore.get_logs(@session) == [@l1, @l2, @l3]
+    end
+
+    test "wraps logs in a list if they are not already in one" do
+      assert LogStore.append_logs(@session, [@l1, @l2]) == [@l1, @l2]
+      assert LogStore.append_logs(@session, @l3) == [@l3]
       assert LogStore.get_logs(@session) == [@l1, @l2, @l3]
     end
   end


### PR DESCRIPTION
This brings support for hovering over elements for Chrome and Selenium.

I attempted to add support for Phantom, but the effort seems better spent on deprecating Phantom instead of adding features to it.

But I admit that it seems misleading considering the current language in the README, which deems Phantom having first class support and selenium/chrome being experimental.

cc/ @keathley @michallepicki 

Resolves #434 