### PR TITLE
Run selenium tests in headless mode in Firefox

### DIFF
--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -45,8 +45,15 @@ defmodule Wallaby.Integration.SessionCase do
 
   defp default_opts_for_driver("phantom"), do: []
   defp default_opts_for_driver("selenium") do
-    [driver: Wallaby.Experimental.Selenium,
-     capabilities: %{browserName: "firefox"}]
+    [
+      driver: Wallaby.Experimental.Selenium,
+      capabilities: %{
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"]
+        }
+      }
+    ]
   end
   defp default_opts_for_driver("chrome"), do: [driver: Wallaby.Experimental.Chrome]
   defp default_opts_for_driver(other) do


### PR DESCRIPTION
Chrome tests are being run in headless mode, so I think we can do that for selenium as well. This is less annoying when using selenium-standalone jar and locally installed firefox, because newly opened windows were stealing system focus.