### PR TITLE
Fix Wallaby.start_session_opts type spec - passing :driver doesn't do anyting

### DIFF
--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -46,7 +46,6 @@ defmodule Wallaby.Integration.SessionCase do
   defp default_opts_for_driver("phantom"), do: []
   defp default_opts_for_driver("selenium") do
     [
-      driver: Wallaby.Experimental.Selenium,
       capabilities: %{
         browserName: "firefox",
         "moz:firefoxOptions": %{
@@ -55,7 +54,7 @@ defmodule Wallaby.Integration.SessionCase do
       }
     ]
   end
-  defp default_opts_for_driver("chrome"), do: [driver: Wallaby.Experimental.Chrome]
+  defp default_opts_for_driver("chrome"), do: []
   defp default_opts_for_driver(other) do
     raise "Unknown value for WALLABY_DRIVER environment variable: #{other}"
   end

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -40,9 +40,7 @@ defmodule Wallaby do
   end
 
   @type reason :: any
-  @type start_session_opts ::
-    {:driver, module} |
-    {atom, any}
+  @type start_session_opts :: {atom, any}
 
   @doc """
   Starts a browser session.

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -7,7 +7,7 @@ defmodule Wallaby.Phantom do
   Start a Wallaby Session using this driver with the following command:
 
   ```
-  {:ok, session} = Wallaby.start_session(driver: Wallaby.Phantom)
+  {:ok, session} = Wallaby.start_session()
   ```
 
   ## Notes


### PR DESCRIPTION
See https://github.com/keathley/wallaby/blob/master/lib/wallaby.ex#L80
While I agree that the `:driver` option could be useful, currently it's not implemented.