### PR TITLE
Enable running hover integration tests added in #435

### DIFF
--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -3,3 +3,5 @@ Code.require_file "../tests.exs", __DIR__
 # Additional test cases supported by chromedriver
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
+Code.require_file "../cases/browser/hover_test.exs", __DIR__
+Code.require_file "../cases/element/hover_test.exs", __DIR__

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -1,1 +1,5 @@
 Code.require_file "../tests.exs", __DIR__
+
+# Additional test cases supported by selenium
+Code.require_file "../cases/browser/hover_test.exs", __DIR__
+Code.require_file "../cases/element/hover_test.exs", __DIR__


### PR DESCRIPTION
@mhanberg Tests weren't added to  Chrome and Selenium lists for tests to run