### PR TITLE
Update and add new elixir and erlang versions used for testing on travis

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.7.4-otp-20
-erlang 20.0
+elixir 1.8.2-otp-21
+erlang 21.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: elixir
 elixir:
   - 1.7.4
-  - 1.8.1
+  - 1.8.2
+  - 1.9.1
 otp_release:
   - 20.3
+  - 21.3
+  - 22.0
 env:
   - ""
   - WALLABY_DRIVER=phantom

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
 sudo: required
 cache:
   directories:
-    - _build
     - deps
 
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: elixir
 elixir:
-  - 1.7.4
   - 1.8.2
   - 1.9.1
 otp_release:
-  - 20.3
   - 21.3
   - 22.0
 env:
   - ""
   - WALLABY_DRIVER=phantom
   - WALLABY_DRIVER=chrome
-  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=3
-  - WALLABY_DRIVER=selenium WALLABY_SELENIUM_VERSION=2
+  - WALLABY_DRIVER=selenium
+matrix:
+  exclude:
+  - elixir: 1.8.2
+    otp_release: 22.0
+  - elixir: 1.9.1
+    otp_release: 21.3
 # Run in bigger container so we don't run out of memory generating the plt
 sudo: required
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 sudo: required
 cache:
   directories:
+    - _build
     - deps
 
 dist: trusty

--- a/dialyzer.ignore_warnings
+++ b/dialyzer.ignore_warnings
@@ -1,3 +1,4 @@
 :0: Unknown function 'Elixir.Mix':shell/0
 :0: Unknown function 'Elixir.Mix.Tasks.Coveralls':do_run/2
 lib/mix/tasks/safe_travis.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
+lib/wallaby/experimental/chrome/logger.ex:35: The pattern

--- a/test/tools/start_webdriver.sh
+++ b/test/tools/start_webdriver.sh
@@ -10,39 +10,26 @@ if [ "$WALLABY_DRIVER" = "selenium" ]; then
   mkdir -p $HOME/bin
   export PATH=$HOME/bin:$PATH
 
-  if [ "$WALLABY_SELENIUM_VERSION" = "3" ]; then
+  curl https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar -o $HOME/selenium.jar
+  # Geckodriver requires java 8.
+  sudo add-apt-repository -y ppa:openjdk-r/ppa
+  sudo apt-get update && sudo apt-get install -y openjdk-8-jdk
 
-    curl https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar -o $HOME/selenium.jar
-    # Geckodriver requires java 8.
-    sudo add-apt-repository -y ppa:openjdk-r/ppa
-    sudo apt-get update && sudo apt-get install -y openjdk-8-jdk
+  # Install jdk switcher to easily change default jdk
+  git clone https://github.com/michaelklishin/jdk_switcher.git $HOME/jdk_switcher
+  . $HOME/jdk_switcher/jdk_switcher.sh
+  jdk_switcher use openjdk8
 
-    # Install jdk switcher to easily change default jdk
-    git clone https://github.com/michaelklishin/jdk_switcher.git $HOME/jdk_switcher
-    . $HOME/jdk_switcher/jdk_switcher.sh
-    jdk_switcher use openjdk8
+  # Download geckodriver
+  curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -o $HOME/geckodriver.tar.gz
+  tar xfz $HOME/geckodriver.tar.gz -C $HOME/bin
 
-    # Download geckodriver
-    curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -o $HOME/geckodriver.tar.gz
-    tar xfz $HOME/geckodriver.tar.gz -C $HOME/bin
-
-    # Download latest firefox
-    export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-latest&lang=en-US&os=linux64'
-    wget -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
-    mkdir -p $HOME/firefox-latest
-    tar xf /tmp/firefox-latest.tar.bz2 -C $HOME/firefox-latest
-    export PATH=$HOME/firefox-latest/firefox:$PATH
-
-  elif [ "$WALLABY_SELENIUM_VERSION" = "2" ]; then
-    curl http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar -o $HOME/selenium.jar
-
-    # Download firefox 46.0 (Well supported by selenium version)
-    export FIREFOX_SOURCE_URL='https://ftp.mozilla.org/pub/firefox/releases/46.0/linux-x86_64/en-US/firefox-46.0.tar.bz2'
-    wget -O /tmp/firefox-46.tar.bz2 $FIREFOX_SOURCE_URL
-    mkdir -p $HOME/firefox-46
-    tar xf /tmp/firefox-46.tar.bz2 -C $HOME/firefox-46
-    export PATH=$HOME/firefox-46/firefox:$PATH
-  fi
+  # Download latest firefox
+  export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-latest&lang=en-US&os=linux64'
+  wget -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
+  mkdir -p $HOME/firefox-latest
+  tar xf /tmp/firefox-latest.tar.bz2 -C $HOME/firefox-latest
+  export PATH=$HOME/firefox-latest/firefox:$PATH
 
   java -version
 


### PR DESCRIPTION
This would be 5 * 3 * 3 = 45 jobs to run so I'm not sure if it's a good idea. Maybe we could reduce the amount of jobs to run for one version combo?

edit: Dropped selenium 2, dropped elixir 1.7 and otp 20, also excluded elixir 1.8+otp22 and elixir 1.9+otp21 to simplify the matrix. Now it's 2x4, looks good but I need to fix the dialyzer warning