### PR TITLE
Switching between frames

### DIFF
--- a/integration_test/cases/browser/frames_test.exs
+++ b/integration_test/cases/browser/frames_test.exs
@@ -1,0 +1,24 @@
+defmodule Wallaby.Integration.Browser.FramesTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  test "switching between frames", %{session: session} do
+    session
+    |> visit("frames.html")
+    |> assert_has(Query.css("h1", text: "Frames Page"))
+    |> assert_has(Query.css("h1", text: "Page 1", count: 0))
+    |> assert_has(Query.css("h1", text: "Page 2", count: 0))
+    |> focus_frame(Query.css("#frame1"))
+    |> assert_has(Query.css("h1", text: "Frames Page", count: 0))
+    |> assert_has(Query.css("h1", text: "Page 1"))
+    |> assert_has(Query.css("h1", text: "Page 2", count: 0))
+    |> focus_parent_frame()
+    |> focus_frame(Query.css("#frame2"))
+    |> assert_has(Query.css("h1", text: "Frames Page", count: 0))
+    |> assert_has(Query.css("h1", text: "Page 1", count: 0))
+    |> assert_has(Query.css("h1", text: "Page 2"))
+    |> focus_frame(nil)
+    |> assert_has(Query.css("h1", text: "Frames Page"))
+    |> assert_has(Query.css("h1", text: "Page 1", count: 0))
+    |> assert_has(Query.css("h1", text: "Page 2", count: 0))
+   end
+end

--- a/integration_test/cases/browser/frames_test.exs
+++ b/integration_test/cases/browser/frames_test.exs
@@ -16,7 +16,7 @@ defmodule Wallaby.Integration.Browser.FramesTest do
     |> assert_has(Query.css("h1", text: "Frames Page", count: 0))
     |> assert_has(Query.css("h1", text: "Page 1", count: 0))
     |> assert_has(Query.css("h1", text: "Page 2"))
-    |> focus_frame(nil)
+    |> focus_default_frame()
     |> assert_has(Query.css("h1", text: "Frames Page"))
     |> assert_has(Query.css("h1", text: "Page 1", count: 0))
     |> assert_has(Query.css("h1", text: "Page 2", count: 0))

--- a/integration_test/support/pages/frames.html
+++ b/integration_test/support/pages/frames.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<head>
+  <title>Frames</title>
+</head>
+
+<body>
+  <h1>Frames Page</h1>
+  <iframe id="frame1" name="frame1" src="page_1.html" height=600 width=600></iframe>
+  <iframe id="frame2" name="frame2" src="page_2.html" height=600 width=600></iframe>
+</body>
+
+</html>

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -324,21 +324,13 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Changes the driver focus to the specified frame.
-
-  You may specify the the frame by passing the frame Query or its id.
-  When passed `nil`, the browser should switch to the page's default context.
+  Changes the driver focus to the frame found by query.
   """
-  @spec focus_frame(parent,  Query.t | String.t | number | nil) :: parent
+  @spec focus_frame(parent,  Query.t) :: parent
 
-  def focus_frame(%{driver: driver} = session, frame_query = %Query{}) do
+  def focus_frame(%{driver: driver} = session, %Query{} = query) do
     session
-    |> find(frame_query, &driver.focus_frame(session, &1))
-  end
-
-  def focus_frame(%{driver: driver} = session, frame_id_or_nil) do
-    {:ok, _} = driver.focus_frame(session, frame_id_or_nil)
-    session
+    |> find(query, &driver.focus_frame(session, &1))
   end
 
   @doc """
@@ -348,6 +340,16 @@ defmodule Wallaby.Browser do
 
   def focus_parent_frame(%{driver: driver} = session) do
     {:ok, _} = driver.focus_parent_frame(session)
+    session
+  end
+
+  @doc """
+  Changes the driver focus to the default (top level) frame.
+  """
+  @spec focus_default_frame(parent) :: parent
+
+  def focus_default_frame(%{driver: driver} = session) do
+    {:ok, _} = driver.focus_frame(session, nil)
     session
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -324,6 +324,34 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
+  Changes the driver focus to the specified frame.
+
+  You may specify the the frame by passing the frame Query or its id.
+  When passed `nil`, the browser should switch to the page's default context.
+  """
+  @spec focus_frame(parent,  Query.t | String.t | number | nil) :: parent
+
+  def focus_frame(%{driver: driver} = session, frame_query = %Query{}) do
+    session
+    |> find(frame_query, &driver.focus_frame(session, &1))
+  end
+
+  def focus_frame(%{driver: driver} = session, frame_id_or_nil) do
+    {:ok, _} = driver.focus_frame(session, frame_id_or_nil)
+    session
+  end
+
+  @doc """
+  Changes the driver focus to the parent frame.
+  """
+  @spec focus_parent_frame(parent) :: parent
+
+  def focus_parent_frame(%{driver: driver} = session) do
+    {:ok, _} = driver.focus_parent_frame(session)
+    session
+  end
+
+  @doc """
   Gets the current url of the session
   """
   @spec current_url(parent) :: String.t

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -88,6 +88,17 @@ defmodule Wallaby.Driver do
   @callback maximize_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
 
   @doc """
+  Invoked to change the driver focus to specified frame.
+  """
+  @callback focus_frame(Session.t | Element.t, String.t | number | nil | Element.t) :: {:ok, any} |
+    {:error, reason}
+
+  @doc """
+  Invoked to change the driver focus to parent frame.
+  """
+  @callback focus_parent_frame(Session.t | Element.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
   Invoked to retrieve the html source of the current page.
   """
   @callback page_source(Session.t) :: {:ok, String.t} | {:error, reason}

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -90,7 +90,7 @@ defmodule Wallaby.Driver do
   @doc """
   Invoked to change the driver focus to specified frame.
   """
-  @callback focus_frame(Session.t | Element.t, String.t | number | nil | Element.t) :: {:ok, any} |
+  @callback focus_frame(Session.t | Element.t, nil | Element.t) :: {:ok, any} |
     {:error, reason}
 
   @doc """

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -161,6 +161,10 @@ defmodule Wallaby.Experimental.Chrome do
   @doc false
   def maximize_window(session), do: delegate(:maximize_window, session)
   @doc false
+  def focus_frame(session, frame), do: delegate(:focus_frame, session, [frame])
+  @doc false
+  def focus_parent_frame(session), do: delegate(:focus_parent_frame, session)
+  @doc false
   def cookies(session), do: delegate(:cookies, session)
   @doc false
   def current_path(session), do: delegate(:current_path, session)

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -87,6 +87,9 @@ defmodule Wallaby.Experimental.Selenium do
   defdelegate set_window_position(session, x, y), to: WebdriverClient
   defdelegate maximize_window(session), to: WebdriverClient
 
+  defdelegate focus_frame(session, frame), to: WebdriverClient
+  defdelegate focus_parent_frame(session), to: WebdriverClient
+
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
   defdelegate accept_confirm(session, fun), to: WebdriverClient

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -426,6 +426,41 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
       do: {:ok, value}
   end
 
+  @doc """
+  Changes focus to another frame
+
+  You may specify the the frame by passing the frame Element or its id.
+  When passed `nil`, the server should switch to the page's default context.
+  """
+  @spec focus_frame(parent, String.t | number | nil | Element.t) :: {:ok, map}
+  def focus_frame(session, frame_element = %Element{}) do
+    with {:ok, resp} <- request(:post, "#{session.url}/frame",
+                                %{
+                                  id: %{
+                                    "ELEMENT" => frame_element.id,
+                                    @web_element_identifier => frame_element.id
+                                  }
+                                }),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  def focus_frame(session, frame) do
+    with {:ok, resp} <- request(:post, "#{session.url}/frame", %{id: frame}),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
+  @doc """
+  Changes focus to parent frame
+  """
+  @spec focus_parent_frame(parent) :: {:ok, map}
+  def focus_parent_frame(session) do
+    with {:ok, resp} <- request(:post, "#{session.url}/frame/parent"),
+          {:ok, value} <- Map.fetch(resp, "value"),
+      do: {:ok, value}
+  end
+
   @spec cast_as_element(Session.t | Element.t, map) :: Element.t
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
           # In the Selenium WebDriver Protocol, the identifier is "ELEMENT":

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -429,11 +429,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   @doc """
   Changes focus to another frame
 
-  You may specify the the frame by passing the frame Element or its id.
-  When passed `nil`, the server should switch to the page's default context.
+  You may specify the the frame by passing the frame Element, its index or id.
+  When passed `nil`, the server should switch to the page's default (top level) frame.
   """
   @spec focus_frame(parent, String.t | number | nil | Element.t) :: {:ok, map}
-  def focus_frame(session, frame_element = %Element{}) do
+  def focus_frame(session, %Element{} = frame_element) do
     with {:ok, resp} <- request(:post, "#{session.url}/frame",
                                 %{
                                   id: %{

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -216,4 +216,6 @@ defmodule Wallaby.Phantom do
   def get_window_position(_session), do: {:error, :not_supported}
   def set_window_position(_session, _x, _y), do: {:error, :not_supported}
   def maximize_window(_session), do: {:error, :not_supported}
+  def focus_frame(_session, _frame), do: {:error, :not_supported}
+  def focus_parent_frame(_session), do: {:error, :not_supported}
 end

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -891,9 +891,29 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       assert {:ok, %{}} = Client.focus_frame(session, frame_element)
     end
 
+    test "sends the correct request to the server when switching to default frame", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      frame_id = nil
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/frame"
+        assert conn.body_params == %{"id" => frame_id}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_frame(session, frame_id)
+    end
+
+
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      frame_id = "my-frame-id"
+      frame_id = 1
 
       handle_request bypass, fn conn ->
         assert conn.method == "POST"

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -4,6 +4,8 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
   alias Wallaby.Experimental.Selenium.WebdriverClient, as: Client
   alias Wallaby.{Element, Query, Session}
 
+  @web_element_identifier "element-6066-11e4-a52e-4f735466cecf"
+
   describe "create_session/2" do
     test "sends the correct request to the webdriver backend", %{bypass: bypass} do
       base_url = bypass_url(bypass) <> "/"
@@ -125,7 +127,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
-          "value": [{"element-6066-11e4-a52e-4f735466cecf": "#{element_id}"}]
+          "value": [{"#{@web_element_identifier}": "#{element_id}"}]
         }>)
       end
 
@@ -866,6 +868,65 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       end
 
       assert {:ok, %{}} = Client.close_window(session)
+    end
+  end
+
+  describe "focus_frame/2" do
+    test "sends the correct request to the server when passed an element", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      frame_element = build_element_for_session(session, "frame-element-id")
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/frame"
+        assert conn.body_params == %{"id" => %{"ELEMENT" => frame_element.id, @web_element_identifier => frame_element.id}}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_frame(session, frame_element)
+    end
+
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      frame_id = "my-frame-id"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/frame"
+        assert conn.body_params == %{"id" => frame_id}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_frame(session, frame_id)
+    end
+  end
+
+  describe "focus_parent_frame/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/frame/parent"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_parent_frame(session)
     end
   end
 


### PR DESCRIPTION
This is a key feature differentiating Selenium/WebDriver from some other automation frameworks like Cypress - Selenium allows switching to frames with different origin while Cypress does not. This is helpful e.g. when testing payments.

To do:
- [x] Document and test switching frames using name, or remove support for it as per [documentation](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidframe). From what I recall this doesn't work using `id` or `name` attribute from HTML DOM element, but only using index in either `window.frames` or `document.getElementsByTagName('iframe')` or some other name. Anyway, using WebElement seems to always work so maybe we should just support that?

edit: What I found is that switching by name/ID is not supported in most WebDrivers. Since switching by WebElement seems to be working fine, I left only Query as a possible argument, but kept all options in the `WebdriverClient` module - this is a private module but if someone really needs switching by index, they'll find it there.

- [x] Maybe extract switching to default frame to a separate function? Currently passing `nil` will switch to default frame

edit: I extracted this to a separate function but in the Browser module only.