### PR TITLE
Don't ship coveralls task in hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -67,6 +67,7 @@ defmodule Wallaby.Mixfile do
   defp package do
     [
       files: ["lib", "mix.exs", "README.md", "LICENSE.md", "priv"],
+      exclude_patterns: ["safe_travis.ex"],
       maintainers: @maintainers,
       licenses: ["MIT"],
       links: %{"Github" => "https://github.com/keathley/wallaby"}


### PR DESCRIPTION
closes #451 

Looks like hex publish uses [`Build.prepare_package()`](https://github.com/hexpm/hex/blob/3c26cf1ae147a45d109f70069591e5df711728b3/lib/mix/tasks/hex.publish.ex#L117) which does [`meta_for`](https://github.com/hexpm/hex/blob/ab402f98c1efe6855c93dfc5130c2b7a4b1ef753/lib/mix/tasks/hex.build.ex#L141) which does [`package`](https://github.com/hexpm/hex/blob/ab402f98c1efe6855c93dfc5130c2b7a4b1ef753/lib/mix/tasks/hex.build.ex#L206) where files are filtered by [`exclude_patterns`](https://github.com/hexpm/hex/blob/ab402f98c1efe6855c93dfc5130c2b7a4b1ef753/lib/mix/tasks/hex.build.ex#L275)

So we should be able to use `exclude_patterns`, not sure why it's not documented in docs for publish but it's probably because of incomplete docs, I'm pretty sure this will work. 