### PR TITLE
Tune Hackney to not overload WebDrivers

### DIFF
--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -32,7 +32,7 @@ defmodule Wallaby do
     children = [
       supervisor(Wallaby.Driver.ProcessWorkspace.ServerSupervisor, []),
       supervisor(driver(), [[name: Wallaby.Driver.Supervisor]]),
-      :hackney_pool.child_spec(:wallaby_pool, [timeout: 15000, max_connections: 4]),
+      :hackney_pool.child_spec(:wallaby_pool, [timeout: 15_000, max_connections: 4]),
       worker(Wallaby.SessionStore, []),
     ]
 

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -32,6 +32,7 @@ defmodule Wallaby do
     children = [
       supervisor(Wallaby.Driver.ProcessWorkspace.ServerSupervisor, []),
       supervisor(driver(), [[name: Wallaby.Driver.Supervisor]]),
+      :hackney_pool.child_spec(:wallaby_pool, [timeout: 15000, max_connections: 4]),
       worker(Wallaby.SessionStore, []),
     ]
 

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -102,7 +102,7 @@ defmodule Wallaby.HTTPClient do
   end
 
   defp request_opts do
-    Application.get_env(:wallaby, :hackney_options, [])
+    Application.get_env(:wallaby, :hackney_options, [hackney: [pool: :wallaby_pool]])
   end
 
   defp headers do


### PR DESCRIPTION
Hopefully this resolves/helps #365 

I have tested this locally with hundreds to thousands of tests running in parallel, and the only reason I've seen it fall apart is because of my computer running out of open file handles.