### PR TITLE
Enhance and standardize capabilities between drivers

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -81,7 +81,7 @@
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.PreferImplicitTry},
@@ -102,7 +102,7 @@
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.UnlessWithElse},
 
         {Credo.Check.Warning.BoolOperationOnSameValues},

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,6 @@ matrix:
   - elixir: 1.9.1
     otp_release: 22.0.7
     env: WALLABY_DRIVER=selenium
-# Run in bigger container so we don't run out of memory generating the plt
-sudo: required
 cache:
   directories:
     - _build
@@ -70,18 +68,16 @@ cache:
 
 dist: trusty
 
+addons:
+  chrome: stable
+  firefox: latest
+
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
   - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes
-  - sudo apt-get update
-  - sudo apt-get --only-upgrade install google-chrome-stable
-  - sudo apt-get install libstdc++6-4.7-dev
   - MIX_ENV=test mix compile --warnings-as-errors
   - if [ -z ${WALLABY_DRIVER} ]; then travis_wait mix dialyzer --plt; fi # only run dialyzer for the env without drivers
   - bash $TRAVIS_BUILD_DIR/test/tools/start_webdriver.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,12 @@ cache:
 dist: trusty
 
 addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - dpkg
+      - google-chrome-stable
   chrome: stable
   firefox: latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
+# Changelog
+
 ## Master
+
+### Improvements
+
+- Enables the ability to set capabilities by passing them as an option and using application configuration.
+- Implements default capabilities for Selenium.
+
+#### Breaking
+
+- Moves configuration options for using chrome headlessly, the chrome binary, and the chromedriver binary to the `:chromedriver` key in the `:wallaby` application config.
 
 ## 0.23.0 (2019-08-14)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/keathley/wallaby/badge.svg?branch=master)](https://coveralls.io/github/keathley/wallaby?branch=master)
 [![Inline docs](http://inch-ci.org/github/keathley/wallaby.svg)](http://inch-ci.org/github/keathley/wallaby)
 
-Wallaby helps you test your web applications by simulating realistic user
-interactions. By default it runs each test case concurrently and manages
-browsers for you. Here's an example test for a simple Todo application:
+Wallaby helps you test your web applications by simulating realistic user interactions.
+By default it runs each test case concurrently and manages browsers for you.
+Here's an example test for a simple Todo application:
 
 ```elixir
 defmodule MyApp.Features.TodoTest do
@@ -26,8 +26,7 @@ defmodule MyApp.Features.TodoTest do
 end
 ```
 
-Because Wallaby manages multiple browsers for you, its possible to test several
-users interacting with a page simultaneously.
+Because Wallaby manages multiple browsers for you, its possible to test several users interacting with a page simultaneously.
 
 ```elixir
 defmodule MyApp.Features.MultipleUsersTest do
@@ -83,10 +82,8 @@ Then ensure that Wallaby is started in your `test_helper.exs`:
 
 ### Phoenix
 
-If you're testing a Phoenix application with Ecto 2 and a database that
-supports sandbox mode then you can enable concurrent testing by adding the
-`Phoenix.Ecto.SQL.Sandbox` plug to your `Endpoint`. It's important that
-this is at the top of `endpoint.ex` before any other plugs.
+If you're testing a Phoenix application with Ecto 2 and a database that supports sandbox mode then you can enable concurrent testing by adding the `Phoenix.Ecto.SQL.Sandbox` plug to your `Endpoint`.
+It's important that this is at the top of `endpoint.ex` before any other plugs.
 
 ```elixir
 # lib/endpoint.ex
@@ -99,8 +96,7 @@ defmodule YourApp.Endpoint do
   end
 ```
 
-Make sure Phoenix is set up to serve endpoints in tests and that the SQL
-sandbox is enabled:
+Make sure Phoenix is set up to serve endpoints in tests and that the SQL sandbox is enabled:
 
 ```elixir
 # config/test.exs
@@ -111,7 +107,8 @@ config :your_app, YourApplication.Endpoint,
 config :your_app, :sql_sandbox, true
 ```
 
-Then in your `test_helper.exs` you can provide some configuration to Wallaby. At minimum, you need to specify a `:base_url`, so Wallaby knows how to resolve relative paths.
+Then in your `test_helper.exs` you can provide some configuration to Wallaby.
+At minimum, you need to specify a `:base_url`, so Wallaby knows how to resolve relative paths.
 
 ```elixir
 # test/test_helper.exs
@@ -121,12 +118,12 @@ Application.put_env(:wallaby, :base_url, YourApplication.Endpoint.url)
 
 #### Assets
 
-Assets are not re-compiled when you run `mix test`. This can lead to confusion if
-you've made changes in javascript or css but tests are still failing. There are two
-common ways to avoid this confusion.
+Assets are not re-compiled when you run `mix test`.
+This can lead to confusion if you've made changes in javascript or css but tests are still failing.
+There are two common ways to avoid this confusion.
 
-The first solution is to run `brunch watch` from the assets directory. This will ensure
-that assets get recompiled after any changes.
+The first solution is to run `brunch watch` from the assets directory.
+This will ensure that assets get recompiled after any changes.
 
 The second solution is to add a new alias to your mix config that recompiles assets for you:
 
@@ -158,10 +155,7 @@ This method is less error prone but it will cause a delay when starting your tes
 
 #### Umbrella Apps
 
-If you're testing an umbrella application containing a Phoenix application for
-the web interface (`MyWebApp`) and a separate persistence application
-(`MyPersistenceApp`) using Ecto 2 with a database that supports
-sandbox mode, then you can use the same setup as above, with a few tweaks.
+If you're testing an umbrella application containing a Phoenix application for the web interface (`MyWebApp`) and a separate persistence application (`MyPersistenceApp`) using Ecto 2 with a database that supports sandbox mode, then you can use the same setup as above, with a few tweaks.
 
 ```elixir
 # my_web_app/lib/endpoint.ex
@@ -174,8 +168,7 @@ defmodule MyWebApp.Endpoint do
   end
 ```
 
-Make sure `MyWebApp` is set up to serve endpoints in tests and that the SQL
-sandbox is enabled:
+Make sure `MyWebApp` is set up to serve endpoints in tests and that the SQL sandbox is enabled:
 
 ```elixir
 # my_web_app/config/test.exs
@@ -186,9 +179,8 @@ config :my_web_app, MyWebApp.Endpoint,
 config :my_persistence_app, :sql_sandbox, true
 ```
 
-Then in `MyWebApp`'s `test_helper.exs` you can provide some configuration to
-Wallaby. At minimum, you need to specify a `:base_url`, so Wallaby knows how to
-resolve relative paths.
+Then in `MyWebApp`'s `test_helper.exs` you can provide some configuration to Wallaby.
+At minimum, you need to specify a `:base_url`, so Wallaby knows how to resolve relative paths.
 
 ```elixir
 # my_web_app/test/test_helper.exs
@@ -231,8 +223,7 @@ config :wallaby, phantomjs_args: "--webdriver-logfile=phantomjs.log"
 
 ### Writing tests
 
-It's easiest to add Wallaby to your test suite by creating a new case template
-(in case of an umbrella app, take care to adjust `YourApp` appropriately):
+It's easiest to add Wallaby to your test suite by creating a new case template (in case of an umbrella app, take care to adjust `YourApp` appropriately):
 
 ```elixir
 defmodule YourApp.FeatureCase do
@@ -291,9 +282,7 @@ The full documentation for the DSL is in the [official documentation](https://he
 
 Wallaby's API is broken into 2 concepts: Queries and Actions.
 
-Queries allow us to declaratively describe the elements that we would like to
-interact with and Actions allow us to use those queries to interact with the
-DOM.
+Queries allow us to declaratively describe the elements that we would like to interact with and Actions allow us to use those queries to interact with the DOM.
 
 Lets say that our html looks like this:
 
@@ -311,10 +300,9 @@ Lets say that our html looks like this:
 </ul>
 ```
 
-If we wanted to interact with all of the users then we could write a query like so
-`css(".user", count: 3)`.
-If we only wanted to interact with a specific user then we could write a query like this `css(".user-name",
-count: 1, text: "Ada")`. Now we can use those queries with some actions:
+If we wanted to interact with all of the users then we could write a query like so `css(".user", count: 3)`.
+
+If we only wanted to interact with a specific user then we could write a query like this `css(".user-name", count: 1, text: "Ada")`. Now we can use those queries with some actions:
 
 ```elixir
 session
@@ -323,12 +311,11 @@ session
 |> assert_has(css(".user-name", count: 1, text: "Ada"))
 ```
 
-There are several queries for common html elements defined in
-the [Query module](https://hexdocs.pm/wallaby/Wallaby.Query.html#content). All
-actions accept a query. This makes it easy to use queries we've already
-defined. Actions will block until the query is either satisfied or the action times
-out. Blocking reduces race conditions when elements are added or removed
-dynamically.
+There are several queries for common html elements defined in the [Query module](https://hexdocs.pm/wallaby/Wallaby.Query.html#content).
+All actions accept a query.
+This makes it easy to use queries we've already defined.
+Actions will block until the query is either satisfied or the action times out.
+Blocking reduces race conditions when elements are added or removed dynamically.
 
 ### Navigation
 
@@ -363,8 +350,7 @@ find(page, @user_form, fn(form) ->
 end)
 ```
 
-Passing a callback to `find` will return the parent which makes it easy to chain
-`find` with other actions:
+Passing a callback to `find` will return the parent which makes it easy to chain `find` with other actions:
 
 ```elixir
 page
@@ -372,8 +358,8 @@ page
 |> click(link("Next Page"))
 ```
 
-Without the callback `find` returns the element. This provides a way to scope
-all future actions within an element.
+Without the callback `find` returns the element.
+This provides a way to scope all future actions within an element.
 
 ```elixir
 page
@@ -395,8 +381,7 @@ click(session, radio_button("My Fancy Radio Button"))
 click(session, button("Some Button"))
 ```
 
-If you need to send specific keys to an element, you can do that with
-`send_keys`:
+If you need to send specific keys to an element, you can do that with `send_keys`:
 
 ```elixir
 send_keys(session, ["Example", "Text", :enter])
@@ -412,9 +397,8 @@ refute_has(session, css(".alert"))
 has?(session, css(".user-edit-modal", visible: false))
 ```
 
-`assert_has` and `refute_has` both take a parent element as their first
-argument. They return that parent, making it easy to chain them together with
-other actions.
+`assert_has` and `refute_has` both take a parent element as their first argument.
+They return that parent, making it easy to chain them together with other actions.
 
 ```elixir
 session
@@ -476,13 +460,12 @@ Application.put_env(:wallaby, :screenshot_on_failure, true)
 
 ### Asynchronous code
 
-Testing asynchronous JavaScript code can expose timing issues and race
-conditions. We might try to interact with an element that hasn't yet appeared on
-the page. Elements can become stale while we're trying to interact with them.
+Testing asynchronous JavaScript code can expose timing issues and race conditions.
+We might try to interact with an element that hasn't yet appeared on the page.
+Elements can become stale while we're trying to interact with them.
 
-Wallaby helps solve this by blocking. Instead of manually setting timeouts we
-can use `assert_has` and some declarative queries to block until the DOM is in a
-good state.
+Wallaby helps solve this by blocking.
+Instead of manually setting timeouts we can use `assert_has` and some declarative queries to block until the DOM is in a good state.
 
 ```elixir
 session
@@ -519,9 +502,13 @@ end
 
 ### JavaScript logging and errors
 
-Wallaby captures both JavaScript logs and errors. Any uncaught exceptions in JavaScript will be re-thrown in Elixir. This can be disabled by specifying `js_errors: false` in your Wallaby config.
+Wallaby captures both JavaScript logs and errors.
+Any uncaught exceptions in JavaScript will be re-thrown in Elixir.
+This can be disabled by specifying `js_errors: false` in your Wallaby config.
 
-JavaScript logs are written to :stdio by default. This can be changed to any IO device by setting the `:js_logger` option in your Wallaby config. For instance if you want to write all JavaScript console logs to a file you could do something like this:
+JavaScript logs are written to :stdio by default.
+This can be changed to any IO device by setting the `:js_logger` option in your Wallaby config.
+For instance if you want to write all JavaScript console logs to a file you could do something like this:
 
 ```elixir
 {:ok, file} = File.open("browser_logs.log", [:write])
@@ -534,10 +521,8 @@ Logging can be disabled by setting `:js_logger` to `nil`.
 
 ### Adjusting timeouts
 
-Wallaby uses [hackney](https://github.com/benoitc/hackney) under the hood, so we
-offer a hook that allows you to control any hackney options you'd like to have
-sent along on every request. This can be controlled with the `:hackney_options`
-setting in `config.exs`.
+Wallaby uses [hackney](https://github.com/benoitc/hackney) under the hood, so we offer a hook that allows you to control any hackney options you'd like to have sent along on every request.
+This can be controlled with the `:hackney_options` setting in `config.exs`.
 
 ```elixir
 config :wallaby,
@@ -550,9 +535,8 @@ config :wallaby,
 
 ### Drivers
 
-Wallaby works with phantomjs out of the box. There is also experimental support for
-both headless chrome and selenium. The driver can be specified by setting the `driver` option in
-the wallaby config like so:
+Wallaby works with PhantomJS out of the box. There is also experimental support for both headless chrome and selenium.
+The driver can be specified by setting the `driver` option in the wallaby config like so:
 
 ```elixir
 # Chrome

--- a/README.md
+++ b/README.md
@@ -553,64 +553,22 @@ See below for more information on the experimental drivers.
 ## Experimental Driver Support
 
 Currently Wallaby provides experimental support for both headless chrome and selenium.
-Both of these drivers are still "experimental" because they don't support the full
-api yet and because the implementation is changing rapidly. But, if you would like
-to use them in your project here's what you'll need to do.
+Both of these drivers are still "experimental" because they don't support the full API yet and because the implementation is changing rapidly.
+But, if you would like to use them in your project here's what you'll need to do.
+
+Please refer to the [documentation](https://hexdocs.pm/wallaby/Wallaby.Experimental.Chrome.html#content) for further information about using the Chrome driver.
 
 ### Headless Chrome
 
-In order to run headless chrome you'll need to have chromedriver 2.30 and chrome 60.
-Previous versions of both of these tools _may_ work, but several features will be
-buggy. If you want to setup chrome in a CI environment then you'll still
-need to install and run xvfb. This is due to a bug in chromedriver 2.30 that inhibits
-chromedriver from handling input text correctly. The bug should be fixed in chromedriver 2.31.
-
-If you would like to disable headless mode in chrome you can pass `headless: false` in your config like so:
-
-```elixir
-config :wallaby,
-  chrome: [
-    headless: false
-  ]
-```
-
-### Custom Chromedriver binary
-
-If `chromedriver` is on your `PATH`, then you can skip this step.
-Otherwise (e.g., on NPM-installed `chromedriver` binaries), you can override the path like so:
-
-```elixir
-config :wallaby, chromedriver: "<path/to/chromedriver>"
-```
-
-
-### Custom Chrome binary
-
-By default chromedriver will find chrome for you but if you want to test against a different version you may use this option to point to the other chrome binary.
-
-```elixir
-config :wallaby,
-  chrome: [
-    binary: "path/to/google/chrome"
-  ]
-```
+In order to run headless chrome you'll need to have ChromeDriver >= 2.30 and chrome >= 60.
+Previous versions of both of these tools _may_ work, but several features will be buggy.
+If you want to setup chrome in a CI environment then you'll still need to install and run xvfb.
+This is due to a bug in ChromeDriver 2.30 that inhibits ChromeDriver from handling input text correctly.
+The bug should be fixed in ChromeDriver 2.31.
 
 ### Selenium
 
-To run selenium you'll need to install selenium-server-standalone and geckodriver.
-Once you have these tools installed you'll need to manually start selenium-server separately
-from your test run.
-
-#### Custom Selenium URL
-
-To configure the `remote_url` that Wallaby will use to connect to the Selenium server, pass it as an option to `Wallaby.start_session`.
-
-```elixir
-Wallaby.start_session(
-  remote_url: "http://selenium:4444/wd/hub/",
-  capabilities: %{browserName: "firefox"}
-)
-```
+Please refer to the [documentation](https://hexdocs.pm/wallaby/Wallaby.Experimental.Selenium.html#content) for further information about using the Selenium driver.
 
 ## Contributing
 

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -13,3 +13,4 @@ Code.require_file "../cases/browser/move_mouse_by_test.exs", __DIR__
 Code.require_file "../cases/browser/send_keys_to_active_element_test.exs", __DIR__
 Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
 Code.require_file "../cases/browser/window_position_test.exs", __DIR__
+Code.require_file "../chrome/capabilities_test.exs", __DIR__

--- a/integration_test/chrome/capabilities_test.exs
+++ b/integration_test/chrome/capabilities_test.exs
@@ -1,5 +1,5 @@
 defmodule Wallaby.Integration.CapabilitiesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Wallaby.DSL
   alias Wallaby.Integration.SessionCase
   alias Wallaby.Experimental.Selenium.WebdriverClient

--- a/integration_test/chrome/capabilities_test.exs
+++ b/integration_test/chrome/capabilities_test.exs
@@ -1,0 +1,97 @@
+defmodule Wallaby.Integration.CapabilitiesTest do
+  use ExUnit.Case, async: true
+  use Wallaby.DSL
+  alias Wallaby.Integration.SessionCase
+  alias Wallaby.Experimental.Selenium.WebdriverClient
+
+  setup do
+    on_exit fn ->
+      Application.delete_env(:wallaby, :chromedriver)
+    end
+  end
+
+  describe "capabilities" do
+    test "reads default capabilities" do
+      expected_capabilities = %{
+        javascriptEnabled: false,
+        loadImages: false,
+        version: "",
+        rotatable: false,
+        takesScreenshot: true,
+        cssSelectorsEnabled: true,
+        nativeEvents: false,
+        platform: "ANY",
+        unhandledPromptBehavior: "accept",
+        loggingPrefs: %{
+          browser: "DEBUG"
+        },
+        chromeOptions: %{
+          args: [
+            "--no-sandbox",
+            "window-size=1280,800",
+            "--disable-gpu",
+            "--headless",
+            "--fullscreen",
+            "--user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+          ]
+        }
+      }
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "reads capabilities from application config" do
+      expected_capabilities = %{chromeOptions: %{args: ["--headless"]}}
+      Application.put_env(:wallaby, :chromedriver, capabilities: expected_capabilities)
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "reads capabilities from opts when also using application config" do
+      Application.put_env(:wallaby, :chromedriver, capabilities: %{})
+      expected_capabilities = %{chromeOptions: %{args: ["--headless"]}}
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} =
+        SessionCase.start_test_session(
+          capabilities: expected_capabilities,
+          create_session_fn: create_session_fn
+        )
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+  end
+end

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -7,3 +7,4 @@ Code.require_file "../cases/element/hover_test.exs", __DIR__
 Code.require_file "../cases/browser/move_mouse_by_test.exs", __DIR__
 Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
 Code.require_file "../cases/browser/window_position_test.exs", __DIR__
+Code.require_file "../selenium/capabilities_test.exs", __DIR__

--- a/integration_test/selenium/capabilities_test.exs
+++ b/integration_test/selenium/capabilities_test.exs
@@ -1,5 +1,5 @@
 defmodule Wallaby.Integration.CapabilitiesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Wallaby.DSL
   alias Wallaby.Integration.SessionCase
   alias Wallaby.Experimental.Selenium.WebdriverClient

--- a/integration_test/selenium/capabilities_test.exs
+++ b/integration_test/selenium/capabilities_test.exs
@@ -1,0 +1,92 @@
+defmodule Wallaby.Integration.CapabilitiesTest do
+  use ExUnit.Case, async: true
+  use Wallaby.DSL
+  alias Wallaby.Integration.SessionCase
+  alias Wallaby.Experimental.Selenium.WebdriverClient
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:wallaby, :selenium)
+    end)
+  end
+
+  describe "capabilities" do
+    test "reads default capabilities" do
+      expected_capabilities = %{
+        javascriptEnabled: true,
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"]
+        }
+      }
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "reads capabilities from application config" do
+      expected_capabilities = %{
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"]
+        }
+      }
+
+      Application.put_env(:wallaby, :selenium, capabilities: expected_capabilities)
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "reads capabilities from opts when also using application config" do
+      Application.put_env(:wallaby, :selenium, capabilities: %{})
+
+      expected_capabilities = %{
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"]
+        }
+      }
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} =
+        SessionCase.start_test_session(
+          capabilities: expected_capabilities,
+          create_session_fn: create_session_fn
+        )
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+  end
+end

--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -15,13 +15,7 @@ defmodule Wallaby.Integration.SessionCase do
   Starts a test session with the default opts for the given driver
   """
   def start_test_session(opts \\ []) do
-    session_opts =
-      "WALLABY_DRIVER"
-      |> System.get_env()
-      |> default_opts_for_driver
-      |> Keyword.merge(opts)
-
-    with {:ok, session} <- retry(2, fn -> Wallaby.start_session(session_opts) end),
+    with {:ok, session} <- retry(2, fn -> Wallaby.start_session(opts) end),
       do: {:ok, session}
   end
 
@@ -41,21 +35,5 @@ defmodule Wallaby.Integration.SessionCase do
       {:ok, session} -> {:ok, session}
       _ -> retry(times - 1, f)
     end
-  end
-
-  defp default_opts_for_driver("phantom"), do: []
-  defp default_opts_for_driver("selenium") do
-    [
-      capabilities: %{
-        browserName: "firefox",
-        "moz:firefoxOptions": %{
-          args: ["-headless"]
-        }
-      }
-    ]
-  end
-  defp default_opts_for_driver("chrome"), do: []
-  defp default_opts_for_driver(other) do
-    raise "Unknown value for WALLABY_DRIVER environment variable: #{other}"
   end
 end

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -27,31 +27,31 @@ defmodule Wallaby.Experimental.Chrome do
 
   def validate do
     with {:ok, executable} <- find_chromedriver_executable() do
-        {version, 0} = System.cmd(executable, ["--version"])
+      {version, 0} = System.cmd(executable, ["--version"])
 
-        @chromedriver_version_regex
-        |> Regex.run(version)
-        |> Enum.drop(1)
-        |> Enum.map(&String.to_integer/1)
-        |> version_check()
+      @chromedriver_version_regex
+      |> Regex.run(version)
+      |> Enum.drop(1)
+      |> Enum.map(&String.to_integer/1)
+      |> version_check()
     end
   end
 
   def find_chromedriver_executable do
     with {:error, :not_found} <-
-            :wallaby
-            |> Application.get_env(:chromedriver, "")
-            |>  Path.expand()
-            |> do_find_chromedriver(),
+           :wallaby
+           |> Application.get_env(:chromedriver, "")
+           |> Path.expand()
+           |> do_find_chromedriver(),
          {:error, :not_found} <- do_find_chromedriver("chromedriver") do
-        exception =
-          DependencyError.exception("""
-          Wallaby can't find chromedriver. Make sure you have chromedriver installed
-          and included in your path.
-          You can also provide a path using `config :wallaby, chromedriver: <path>`.
-          """)
+      exception =
+        DependencyError.exception("""
+        Wallaby can't find chromedriver. Make sure you have chromedriver installed
+        and included in your path.
+        You can also provide a path using `config :wallaby, chromedriver: <path>`.
+        """)
 
-        {:error, exception}
+      {:error, exception}
     end
   end
 
@@ -69,7 +69,7 @@ defmodule Wallaby.Experimental.Chrome do
   end
 
   defp version_check([major_version, minor_version])
-    when major_version == 2 and minor_version >= 30 do
+       when major_version == 2 and minor_version >= 30 do
     :ok
   end
 
@@ -154,6 +154,7 @@ defmodule Wallaby.Experimental.Chrome do
   @doc false
   def set_window_size(session, width, height),
     do: delegate(:set_window_size, session, [width, height])
+
   @doc false
   def get_window_position(session), do: delegate(:get_window_position, session)
   @doc false
@@ -193,7 +194,9 @@ defmodule Wallaby.Experimental.Chrome do
   @doc false
   def hover(element), do: delegate(:move_mouse_to, element, [element])
   @doc false
-  def move_mouse_by(parent, x_offset, y_offset), do: delegate(:move_mouse_to, parent, [nil, x_offset, y_offset])
+  def move_mouse_by(parent, x_offset, y_offset),
+    do: delegate(:move_mouse_to, parent, [nil, x_offset, y_offset])
+
   @doc false
   def clear(element), do: delegate(:clear, element)
   @doc false

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -206,7 +206,7 @@ defmodule Wallaby.Experimental.Chrome do
   end
 
   @doc false
-  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session()
+  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session() | no_return
   def start_session(opts \\ []) do
     {:ok, base_url} = Chromedriver.base_url()
     create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
@@ -215,6 +215,10 @@ defmodule Wallaby.Experimental.Chrome do
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
+
+      if id == nil do
+        raise inspect(response)
+      end
 
       session = %Wallaby.Session{
         session_url: base_url <> "session/#{id}",

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -232,9 +232,6 @@ defmodule Wallaby.Experimental.Chrome do
         do: {:ok, _} = set_window_size(session, window_size[:width], window_size[:height])
 
       {:ok, session}
-    else
-      error ->
-        raise inspect(error)
     end
   end
 

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -206,8 +206,8 @@ defmodule Wallaby.Experimental.Chrome do
   end
 
   @doc false
-  @spec start_session([start_session_opts]) :: {:ok, Session.t()}
-  def start_session(opts) do
+  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session()
+  def start_session(opts \\ []) do
     {:ok, base_url} = Chromedriver.base_url()
     create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
 

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -1,5 +1,107 @@
 defmodule Wallaby.Experimental.Chrome do
-  @moduledoc false
+  @moduledoc """
+  The Chrome driver uses [Chromedriver](https://sites.google.com/a/chromium.org/chromedriver/) to power Google Chrome and Chromium.
+
+  ## Usage
+
+  Start a Wallaby Session using this driver with the following command:
+
+  ```
+  {:ok, session} = Wallaby.start_session()
+  ```
+
+  ## Configuration
+
+  ### Headless
+
+  Chrome will run headlessly by default.
+  You can disable this behaviour using the following configuration.
+
+  This will override the default capabilities and capabilities set with application configuration.
+  This will _not_ override capabilities passed in directly to `Wallaby.start_session/1`.
+
+  ```
+  config :wallaby,
+    chromedriver: [
+      headless: false
+    ]
+  ```
+
+  ### Capabilities
+
+  These capabilities will override the default capabilities.
+
+  ```
+  config :wallaby,
+    chromedriver: [
+      capabilities: %{
+        # something
+      }
+    ]
+  ```
+
+  ### ChromeDriver binary
+
+  If ChromeDriver is not available in your path, you can specify it's location.
+
+  ```
+  config :wallaby,
+    chromedriver: [
+      path: "path/to/chrome"
+    ]
+  ```
+
+  ### Chrome binary
+
+  This configures which instance of Google Chrome to use.
+
+  This will override the default capabilities and capabilities set with application configuration.
+  This will _not_ override capabilities passed in directly to `Wallaby.start_session/1`.
+
+  ```
+  config :wallaby,
+    chromedriver: [
+      binary: "path/to/chrome"
+    ]
+  ```
+
+  ## Default Capabilities
+
+  By default, Chromdriver will use the following capabilities
+
+  You can read more about capabilities in the [JSON Wire Protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#capabilities-json-object) documentation and the [Chromedriver](https://sites.google.com/a/chromium.org/chromedriver/capabilities) documentation.
+
+  ```elixir
+    %{
+      javascriptEnabled: false,
+      loadImages: false,
+      version: "",
+      rotatable: false,
+      takesScreenshot: true,
+      cssSelectorsEnabled: true,
+      nativeEvents: false,
+      platform: "ANY",
+      unhandledPromptBehavior: "accept",
+      loggingPrefs: %{
+        browser: "DEBUG"
+      },
+      chromeOptions: %{
+        args: [
+          "--no-sandbox",
+          "window-size=1280,800",
+          "--disable-gpu",
+          "--headless",
+          "--fullscreen",
+          "--user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+        ]
+      }
+    }
+  ```
+
+  ## Notes
+
+  This driver requires [Chromedriver](https://sites.google.com/a/chromium.org/chromedriver/) to be installed in your path.
+  """
   use Supervisor
 
   @behaviour Wallaby.Driver
@@ -11,11 +113,28 @@ defmodule Wallaby.Experimental.Chrome do
   alias Wallaby.Experimental.Selenium.WebdriverClient
   import Wallaby.Driver.LogChecker
 
+  @typedoc """
+  Options to pass to Wallaby.start_session/1
+
+  ```elixir
+  Wallaby.start_session(
+    capabilities: %{chromeOptions: %{args: ["--headless"]}},
+    create_session_fn: fn url, capabilities ->
+      WebdriverClient.create_session(url, capabilities)
+    end
+  )
+  ```
+  """
+  @type start_session_opts ::
+          {:capabilities, map}
+          | {:create_session_fn, (String.t(), map -> {:ok, %{}})}
+
   @doc false
   def start_link(opts \\ []) do
     Supervisor.start_link(__MODULE__, :ok, opts)
   end
 
+  @doc false
   def init(:ok) do
     children = [
       worker(Wallaby.Experimental.Chrome.Chromedriver, []),
@@ -25,6 +144,7 @@ defmodule Wallaby.Experimental.Chrome do
     supervise(children, strategy: :one_for_one)
   end
 
+  @doc false
   def validate do
     with {:ok, executable} <- find_chromedriver_executable() do
       {version, 0} = System.cmd(executable, ["--version"])
@@ -37,10 +157,12 @@ defmodule Wallaby.Experimental.Chrome do
     end
   end
 
+  @doc false
   def find_chromedriver_executable do
     with {:error, :not_found} <-
            :wallaby
-           |> Application.get_env(:chromedriver, "")
+           |> Application.get_env(:chromedriver, [])
+           |> Keyword.get(:path, "")
            |> Path.expand()
            |> do_find_chromedriver(),
          {:error, :not_found} <- do_find_chromedriver("chromedriver") do
@@ -83,15 +205,13 @@ defmodule Wallaby.Experimental.Chrome do
     {:error, exception}
   end
 
+  @doc false
+  @spec start_session([start_session_opts]) :: {:ok, Session.t()}
   def start_session(opts) do
     {:ok, base_url} = Chromedriver.base_url()
     create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
 
-    user_agent =
-      user_agent()
-      |> Metadata.append(opts[:metadata])
-
-    capabilities = capabilities(user_agent: user_agent)
+    capabilities = Keyword.get(opts, :capabilities, capabilities_from_config(opts))
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
@@ -111,12 +231,22 @@ defmodule Wallaby.Experimental.Chrome do
     end
   end
 
+  defp capabilities_from_config(opts) do
+    :wallaby
+    |> Application.get_env(:chromedriver, [])
+    |> Keyword.get(:capabilities, default_capabilities(opts))
+    |> put_headless_config()
+    |> put_binary_config()
+  end
+
+  @doc false
   def end_session(%Wallaby.Session{} = session, opts \\ []) do
     end_session_fn = Keyword.get(opts, :end_session_fn, &WebdriverClient.delete_session/1)
     end_session_fn.(session)
     :ok
   end
 
+  @doc false
   def blank_page?(session) do
     case current_url(session) do
       {:ok, url} ->
@@ -133,12 +263,19 @@ defmodule Wallaby.Experimental.Chrome do
     end)
   end
 
+  @doc false
   defdelegate accept_alert(session, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  @doc false
   defdelegate accept_confirm(session, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_confirm(session, fun), to: WebdriverClient
+  @doc false
   defdelegate accept_prompt(session, input, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_prompt(session, fun), to: WebdriverClient
+  @doc false
   defdelegate parse_log(log), to: Wallaby.Experimental.Chrome.Logger
 
   @doc false
@@ -249,17 +386,13 @@ defmodule Wallaby.Experimental.Chrome do
   @doc false
   defdelegate log(session_or_element), to: WebdriverClient
 
-  @doc false
-  def user_agent do
-    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
-  end
+  defp default_capabilities(opts) do
+    user_agent =
+      Metadata.append(
+        "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
+        opts[:metadata]
+      )
 
-  defp capabilities(opts) do
-    default_capabilities()
-    |> Map.put(:chromeOptions, chrome_options(opts))
-  end
-
-  defp default_capabilities do
     %{
       javascriptEnabled: false,
       loadImages: false,
@@ -272,52 +405,47 @@ defmodule Wallaby.Experimental.Chrome do
       unhandledPromptBehavior: "accept",
       loggingPrefs: %{
         browser: "DEBUG"
+      },
+      chromeOptions: %{
+        args: [
+          "--no-sandbox",
+          "window-size=1280,800",
+          "--disable-gpu",
+          "--headless",
+          "--fullscreen",
+          "--user-agent=#{user_agent}"
+        ]
       }
     }
   end
 
-  defp chrome_options(opts) do
-    %{args: chrome_args(opts)}
-    |> put_unless_nil(:binary, chrome_binary_option())
+  defp put_headless_config(capabilities) do
+    headless? = Application.get_env(:wallaby, :chromedriver, []) |> Keyword.get(:headless)
+
+    capabilities
+    |> update_unless_nil(:args, headless?, fn args ->
+      if headless? do
+        (args ++ ["--headless"])
+        |> Enum.uniq()
+      else
+        args -- ["--headless"]
+      end
+    end)
   end
 
-  defp chrome_args(opts) do
-    default_chrome_args()
-    |> Enum.concat(headless_args())
-    |> Enum.concat(user_agent_arg(opts[:user_agent]))
+  defp put_binary_config(capabilities) do
+    binary_path = Application.get_env(:wallaby, :chromedriver, []) |> Keyword.get(:binary)
+
+    capabilities
+    |> update_unless_nil(:binary, binary_path, fn _ ->
+      binary_path
+    end)
   end
 
-  defp user_agent_arg(nil), do: []
-  defp user_agent_arg(ua), do: ["--user-agent=#{ua}"]
+  defp update_unless_nil(capabilities, _key, nil, _updater), do: capabilities
 
-  defp headless? do
-    :wallaby
-    |> Application.get_env(:chrome, [])
-    |> Keyword.get(:headless, true)
+  defp update_unless_nil(capabilities, key, _, updater) do
+    capabilities
+    |> update_in([:chromeOptions, key], updater)
   end
-
-  defp chrome_binary_option do
-    :wallaby
-    |> Application.get_env(:chrome, [])
-    |> Keyword.get(:binary)
-  end
-
-  def default_chrome_args do
-    [
-      "--no-sandbox",
-      "window-size=1280,800",
-      "--disable-gpu"
-    ]
-  end
-
-  defp headless_args do
-    if headless?() do
-      ["--fullscreen", "--headless"]
-    else
-      []
-    end
-  end
-
-  defp put_unless_nil(map, _key, nil), do: map
-  defp put_unless_nil(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -216,10 +216,6 @@ defmodule Wallaby.Experimental.Chrome do
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
 
-      if id == nil do
-        raise inspect(response)
-      end
-
       session = %Wallaby.Session{
         session_url: base_url <> "session/#{id}",
         url: base_url <> "session/#{id}",

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -228,6 +228,9 @@ defmodule Wallaby.Experimental.Chrome do
         do: {:ok, _} = set_window_size(session, window_size[:width], window_size[:height])
 
       {:ok, session}
+    else
+      error ->
+        raise inspect(error)
     end
   end
 

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -1,5 +1,52 @@
 defmodule Wallaby.Experimental.Selenium do
-  @moduledoc false
+  @moduledoc """
+  The Selenium driver uses [Selenium Server](https://github.com/SeleniumHQ/selenium) to power many types of browsers (Chrome, Firefox, Edge, etc).
+
+  ## Usage
+
+  Start a Wallaby Session using this driver with the following command:
+
+  ```
+  {:ok, session} = Wallaby.start_session()
+  ```
+
+  ## Configuration
+
+  ### Capabilities
+
+  These capabilities will override the default capabilities.
+
+  ```
+  config :wallaby,
+    selenium: [
+      capabilities: %{
+        # something
+      }
+    ]
+  ```
+
+  ## Default Capabilities
+
+  By default, Selenium will use the following capabilities
+
+  You can read more about capabilities in the [JSON Wire Protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#capabilities-json-object) documentation.
+
+  ```elixir
+  %{
+    javascriptEnabled: true,
+    browserName: "firefox",
+    "moz:firefoxOptions": %{
+      args: ["-headless"]
+    }
+  }
+  ```
+
+  ## Notes
+
+  - Requires [selenium-server-standalone](https://www.seleniumhq.org/download/) to be running on port 4444. Wallaby does _not_ manage the start/stop of the Selenium server.
+  - Requires [GeckoDriver](https://github.com/mozilla/geckodriver) to be installed in your path when using [Firefox](https://www.mozilla.org/en-US/firefox/new/). Firefox is used by default.
+  """
+
   use Supervisor
 
   @behaviour Wallaby.Driver
@@ -7,34 +54,49 @@ defmodule Wallaby.Experimental.Selenium do
   alias Wallaby.{Driver, Element, Session}
   alias Wallaby.Experimental.Selenium.WebdriverClient
 
-  @type start_session_opts ::
-    {:remote_url, String.t} |
-    {:capabilities, map} |
-    {:create_session_fn, ((String.t, map) -> {:ok, %{}})}
+  @typedoc """
+  Options to pass to Wallaby.start_session/1
 
+  ```elixir
+  Wallaby.start_session(
+    remote_url: "http://selenium_url",
+    capabilities: %{browserName: "firefox"},
+    create_session_fn: fn url, capabilities ->
+      WebdriverClient.create_session(url, capabilities)
+    end
+  )
+  ```
+  """
+  @type start_session_opts ::
+          {:remote_url, String.t()}
+          | {:capabilities, map}
+          | {:create_session_fn, (String.t(), map -> {:ok, %{}})}
+
+  @typedoc false
+  @type end_session_opts :: {:end_session_fn, (Session.t() -> any)}
+
+  @doc false
   def start_link(opts \\ []) do
     Supervisor.start_link(__MODULE__, :ok, opts)
   end
 
+  @doc false
   def init(:ok) do
-    children = [
-    ]
-
-    supervise(children, strategy: :one_for_one)
+    supervise([], strategy: :one_for_one)
   end
 
+  @doc false
   def validate do
     :ok
   end
 
-  @spec start_session([start_session_opts]) :: {:ok, Session.t}
+  @doc false
+  @spec start_session([start_session_opts]) :: {:ok, Session.t()}
   def start_session(opts \\ []) do
     base_url = Keyword.get(opts, :remote_url, "http://localhost:4444/wd/hub/")
-    capabilities = Keyword.get(opts, :capabilities, %{})
-    create_session_fn = Keyword.get(opts, :create_session_fn,
-                                    &WebdriverClient.create_session/2)
+    create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
 
-    capabilities = Map.merge(default_capabilities(), capabilities)
+    capabilities = Keyword.get(opts, :capabilities, capabilities_from_config())
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
@@ -53,156 +115,204 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
-  @type end_session_opts ::
-    {:end_session_fn, ((Session.t) -> any)}
+  defp capabilities_from_config() do
+    :wallaby
+    |> Application.get_env(:selenium, [])
+    |> Keyword.get(:capabilities, default_capabilities())
+  end
 
-  @doc """
-  Invoked to end a browser session.
-  """
-  @spec end_session(Session.t, [end_session_opts]) :: :ok
+  @doc false
+  @spec end_session(Session.t(), [end_session_opts]) :: :ok
   def end_session(session, opts \\ []) do
-    end_session_fn =
-      Keyword.get(opts, :end_session_fn, &WebdriverClient.delete_session/1)
+    end_session_fn = Keyword.get(opts, :end_session_fn, &WebdriverClient.delete_session/1)
 
     end_session_fn.(session)
     :ok
   end
 
+  @doc false
   def blank_page?(session) do
     case current_url(session) do
       {:ok, url} ->
         url == "about:blank"
+
       _ ->
         false
     end
   end
 
+  @doc false
   defdelegate window_handle(session), to: WebdriverClient
+  @doc false
   defdelegate window_handles(session), to: WebdriverClient
+  @doc false
   defdelegate focus_window(session, window_handle), to: WebdriverClient
+  @doc false
   defdelegate close_window(session), to: WebdriverClient
+  @doc false
   defdelegate get_window_size(session), to: WebdriverClient
+  @doc false
   defdelegate set_window_size(session, width, height), to: WebdriverClient
+  @doc false
   defdelegate get_window_position(session), to: WebdriverClient
+  @doc false
   defdelegate set_window_position(session, x, y), to: WebdriverClient
+  @doc false
   defdelegate maximize_window(session), to: WebdriverClient
 
+  @doc false
   defdelegate focus_frame(session, frame), to: WebdriverClient
+  @doc false
   defdelegate focus_parent_frame(session), to: WebdriverClient
 
+  @doc false
   defdelegate accept_alert(session, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  @doc false
   defdelegate accept_confirm(session, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_confirm(session, fun), to: WebdriverClient
+  @doc false
   defdelegate accept_prompt(session, input, fun), to: WebdriverClient
+  @doc false
   defdelegate dismiss_prompt(session, fun), to: WebdriverClient
 
+  @doc false
   defdelegate take_screenshot(session_or_element), to: WebdriverClient
 
+  @doc false
   def cookies(%Session{} = session) do
     WebdriverClient.cookies(session)
   end
 
+  @doc false
   def current_path(%Session{} = session) do
-    with  {:ok, url} <- WebdriverClient.current_url(session),
-          uri <- URI.parse(url),
-          {:ok, path} <- Map.fetch(uri, :path),
-      do: {:ok, path}
+    with {:ok, url} <- WebdriverClient.current_url(session),
+         uri <- URI.parse(url),
+         {:ok, path} <- Map.fetch(uri, :path),
+         do: {:ok, path}
   end
 
+  @doc false
   def current_url(%Session{} = session) do
     WebdriverClient.current_url(session)
   end
 
+  @doc false
   def page_source(%Session{} = session) do
     WebdriverClient.page_source(session)
   end
 
+  @doc false
   def page_title(%Session{} = session) do
     WebdriverClient.page_title(session)
   end
 
+  @doc false
   def set_cookie(%Session{} = session, key, value) do
     WebdriverClient.set_cookie(session, key, value)
   end
 
+  @doc false
   def visit(%Session{} = session, path) do
     WebdriverClient.visit(session, path)
   end
 
+  @doc false
   def attribute(%Element{} = element, name) do
     WebdriverClient.attribute(element, name)
   end
 
-  @spec clear(Element.t) :: {:ok, nil} | {:error, Driver.reason}
+  @doc false
+  @spec clear(Element.t()) :: {:ok, nil} | {:error, Driver.reason()}
   def clear(%Element{} = element) do
     WebdriverClient.clear(element)
   end
 
+  @doc false
   def click(%Element{} = element) do
     WebdriverClient.click(element)
   end
 
+  @doc false
   def click(parent, button) do
     WebdriverClient.click(parent, button)
   end
 
+  @doc false
   def button_down(parent, button) do
     WebdriverClient.button_down(parent, button)
   end
 
+  @doc false
   def button_up(parent, button) do
     WebdriverClient.button_up(parent, button)
   end
 
+  @doc false
   def double_click(parent) do
     WebdriverClient.double_click(parent)
   end
 
+  @doc false
   def hover(%Element{} = element) do
     WebdriverClient.move_mouse_to(nil, element)
   end
 
+  @doc false
   def move_mouse_by(session, x_offset, y_offset) do
     WebdriverClient.move_mouse_to(session, nil, x_offset, y_offset)
   end
 
+  @doc false
   def displayed(%Element{} = element) do
     WebdriverClient.displayed(element)
   end
 
+  @doc false
   def selected(%Element{} = element) do
     WebdriverClient.selected(element)
   end
 
-  @spec set_value(Element.t, String.t) :: {:ok, nil} | {:error, Driver.reason}
+  @doc false
+  @spec set_value(Element.t(), String.t()) :: {:ok, nil} | {:error, Driver.reason()}
   def set_value(%Element{} = element, value) do
     WebdriverClient.set_value(element, value)
   end
 
+  @doc false
   def text(%Element{} = element) do
     WebdriverClient.text(element)
   end
 
+  @doc false
   def find_elements(parent, compiled_query) do
     WebdriverClient.find_elements(parent, compiled_query)
   end
 
+  @doc false
   def execute_script(parent, script, arguments \\ []) do
     WebdriverClient.execute_script(parent, script, arguments)
   end
 
+  @doc false
   def execute_script_async(parent, script, arguments \\ []) do
     WebdriverClient.execute_script_async(parent, script, arguments)
   end
 
+  @doc false
   def send_keys(parent, keys) do
     WebdriverClient.send_keys(parent, keys)
   end
 
   defp default_capabilities do
     %{
-      javascriptEnabled: true
+      javascriptEnabled: true,
+      browserName: "firefox",
+      "moz:firefoxOptions": %{
+        args: ["-headless"]
+      }
     }
   end
 end

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -101,10 +101,6 @@ defmodule Wallaby.Experimental.Selenium do
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
 
-      if id == nil do
-        raise inspect(response)
-      end
-
       session = %Wallaby.Session{
         session_url: base_url <> "session/#{id}",
         url: base_url <> "session/#{id}",

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -91,7 +91,7 @@ defmodule Wallaby.Experimental.Selenium do
   end
 
   @doc false
-  @spec start_session([start_session_opts]) :: {:ok, Session.t()}
+  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session()
   def start_session(opts \\ []) do
     base_url = Keyword.get(opts, :remote_url, "http://localhost:4444/wd/hub/")
     create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -91,7 +91,7 @@ defmodule Wallaby.Experimental.Selenium do
   end
 
   @doc false
-  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session()
+  @spec start_session([start_session_opts]) :: Wallaby.Driver.on_start_session() | no_return
   def start_session(opts \\ []) do
     base_url = Keyword.get(opts, :remote_url, "http://localhost:4444/wd/hub/")
     create_session_fn = Keyword.get(opts, :create_session_fn, &WebdriverClient.create_session/2)
@@ -100,6 +100,10 @@ defmodule Wallaby.Experimental.Selenium do
 
     with {:ok, response} <- create_session_fn.(base_url, capabilities) do
       id = response["sessionId"]
+
+      if id == nil do
+        raise inspect(response)
+      end
 
       session = %Wallaby.Session{
         session_url: base_url <> "session/#{id}",

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -116,9 +116,6 @@ defmodule Wallaby.Experimental.Selenium do
         do: {:ok, _} = set_window_size(session, window_size[:width], window_size[:height])
 
       {:ok, session}
-    else
-      error ->
-        raise inspect(error)
     end
   end
 

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -112,6 +112,9 @@ defmodule Wallaby.Experimental.Selenium do
         do: {:ok, _} = set_window_size(session, window_size[:width], window_size[:height])
 
       {:ok, session}
+    else
+      error ->
+        raise inspect(error)
     end
   end
 

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -29,7 +29,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   """
   @spec delete_session(Session.t() | Element.t()) :: {:ok, map}
   def delete_session(session) do
-    request(:delete, session.session_url, %{})
+      request(:delete, session.session_url, %{})
+  rescue
+    _ -> {:ok, %{}}
   end
 
   @doc """

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -96,6 +96,8 @@ defmodule Wallaby.HTTPClient do
         {:error, :invalid_selector}
       %{"message" => "unexpected alert" <> _} ->
         {:error, :unexpected_alert}
+      %{"error" => _, "message" => message} ->
+        raise message
       _ ->
         {:ok, response}
     end

--- a/test/tools/start_webdriver.sh
+++ b/test/tools/start_webdriver.sh
@@ -24,13 +24,6 @@ if [ "$WALLABY_DRIVER" = "selenium" ]; then
   curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -o $HOME/geckodriver.tar.gz
   tar xfz $HOME/geckodriver.tar.gz -C $HOME/bin
 
-  # Download latest firefox
-  export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-latest&lang=en-US&os=linux64'
-  wget -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
-  mkdir -p $HOME/firefox-latest
-  tar xf /tmp/firefox-latest.tar.bz2 -C $HOME/firefox-latest
-  export PATH=$HOME/firefox-latest/firefox:$PATH
-
   java -version
 
   nohup java -jar $HOME/selenium.jar &

--- a/test/wallaby/http_client_test.exs
+++ b/test/wallaby/http_client_test.exs
@@ -82,5 +82,23 @@ defmodule Wallaby.HTTPClientTest do
         Client.request(:post, bypass_url(bypass, "/my_url"))
       end
     end
+
+    test "raises a runtime error when the request returns a generic error", %{bypass: bypass} do
+      expected_message = "The session could not be created"
+
+      Bypass.expect bypass, fn conn ->
+        send_resp(conn, 200, ~s<{
+          "sessionId": "abc123",
+          "value": {
+            "error": "An error",
+            "message": "#{expected_message}"
+          }
+        }>)
+      end
+
+      assert_raise RuntimeError, expected_message, fn ->
+        Client.request(:post, bypass_url(bypass, "/my_url"))
+      end
+    end
   end
 end


### PR DESCRIPTION
- Enables the ability to set capabilities by passing them as an option and using application configuration.
- Implements default capabilities for Selenium.
- Moves configuration options for using chrome headlessly, the chrome binary, and the chromedriver binary to the `:chromedriver` key in the `:wallaby` application config.
- Moves documentation for Chrome and Selenium from the README and into their respective moduledocs.
- Raise when we receive a generic error from the driver
- Disables a few credo rules that I don't think are valuable: ParenthesesOnZeroArtiyDefs conflicts with the formatter and PipeChainStart is not useful as a code quality metric

cc/ @michallepicki 

Resolves #460