### PR TITLE
Reproduce chrome staying open after test completes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,5 +2,31 @@ import Config
 
 # Prevents timeouts in ExUnit
 config :wallaby,
-  hackney_options: [timeout: 10_000, recv_timeout: 10_000],
-  tmp_dir_prefix: "wallaby_test"
+  hackney_options: [timeout: 10, recv_timeout: 10],
+  tmp_dir_prefix: "wallaby_test",
+  chromedriver: [
+    headless: false,
+    capabilities: %{
+      javascriptEnabled: false,
+      loadImages: false,
+      version: "",
+      rotatable: false,
+      takesScreenshot: true,
+      cssSelectorsEnabled: true,
+      nativeEvents: false,
+      platform: "ANY",
+      unhandledPromptBehavior: "accept",
+      loggingPrefs: %{
+        browser: "DEBUG"
+      },
+      chromeOptions: %{
+        args: [
+          "--no-sandbox",
+          "--enable-gpu",
+          "window-size=1280,800",
+          "--fullscreen",
+          "--user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+        ]
+      }
+    }
+  ]


### PR DESCRIPTION
To reproduce run:

    WALLABY_DRIVER=chrome mix test integration_test/cases/browser/assert_refute_has_test.exs:29

When it fails it looks like:
```
❯ WALLABY_DRIVER=chrome mix test integration_test/cases/browser/assert_refute_has_test.exs:29
warning: :simple_one_for_one strategy is deprecated, please use DynamicSupervisor instead
  (elixir 1.18.1) lib/supervisor.ex:762: Supervisor.init/2
  (elixir 1.18.1) lib/supervisor.ex:707: Supervisor.start_link/2
  (kernel 10.2) application_master.erl:295: :application_master.start_it_old/4

Running ExUnit with seed: 303648, max_cases: 16
Excluding tags: [:test]
Including tags: [location: {"integration_test/cases/browser/assert_refute_has_test.exs", 29}]



  1) test assert_has/2 mentions the count of found vs. expected elements (Wallaby.Integration.Browser.AssertRefuteHasTest)
     integration_test/cases/browser/assert_refute_has_test.exs:29
     ** (RuntimeError) Wallaby had an internal issue with HTTPoison:
     %HTTPoison.Error{reason: :timeout, id: nil}
     stacktrace:
       (wallaby 0.30.10) lib/wallaby/httpclient.ex:50: Wallaby.HTTPClient.make_request/5
       (wallaby 0.30.10) lib/wallaby/chrome.ex:345: Wallaby.Chrome.start_session/1
       (wallaby 0.30.10) lib/wallaby.ex:85: Wallaby.start_session/1
       integration_test/support/session_case.ex:35: Wallaby.Integration.SessionCase.retry/2
       integration_test/support/session_case.ex:27: Wallaby.Integration.SessionCase.inject_test_session/1
       integration_test/support/session_case.ex:1: Wallaby.Integration.SessionCase.__ex_unit__/2
       integration_test/cases/browser/assert_refute_has_test.exs:1: Wallaby.Integration.Browser.AssertRefuteHasTest.__ex_unit__/2


Finished in 0.3 seconds (0.3s async, 0.00s sync)
7 tests, 1 failure, 6 excluded
```

Edit: I meant to open this as a PR on my fork instead. Whoops!