### PR TITLE
fix: bug in shutdown — pid2 is assigned from  $1 instead of $2

### DIFF
--- a/priv/run_command.sh
+++ b/priv/run_command.sh
@@ -10,7 +10,7 @@ echo "PID: $pid1"
 
 shutdown(){
     local pid1=$1
-    local pid2=$1
+    local pid2=$2
 
     if [ $script_status = "running" ]; then
         script_status="shutting down"


### PR DESCRIPTION
pid2 is assigned from  $1 instead of $2 , therefore pid2 isn’t used correctly.