### PR TITLE
docs: correct Spelling of 'Chromedriver' in Documentation

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -67,7 +67,7 @@ defmodule Wallaby.Chrome do
 
   ## Default Capabilities
 
-  By default, Chromdriver will use the following capabilities
+  By default, Chromedriver will use the following capabilities
 
   You can read more about capabilities in the [JSON Wire Protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#capabilities-json-object) documentation and the [Chromedriver](https://sites.google.com/a/chromium.org/chromedriver/capabilities) documentation.
 


### PR DESCRIPTION
A one-line change to correct the spelling of Chromedriver from 'Chromdriver' in the `Wallaby.Chrome` module documentation.